### PR TITLE
[codex] Improve experimentation skill workflows

### DIFF
--- a/plugins/experimentation/skills/advanced-experiment-analysis/SKILL.md
+++ b/plugins/experimentation/skills/advanced-experiment-analysis/SKILL.md
@@ -1,300 +1,351 @@
 ---
 name: advanced-experiment-analysis
-description: "Analyze complex experiments using sequential testing, Bayesian decision rules, CUPED/CUPAC, ratio metrics, correlated observations, clustered behavior, CATE, uplift modeling, or bandit-vs-controlled experiment tradeoffs."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Analyze complex experiments using sequential testing, Bayesian decision rules, CUPED/CUPAC, ratio metrics, correlated observations, clustered behavior, CATE, uplift modeling, or bandit-vs-controlled experiment tradeoffs. Proactively suggest this skill when ordinary two-proportion or t-test analysis is not adequate.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - sequential
+  - Bayesian
+  - CUPED
+  - CUPAC
+  - ratio metric
+  - clustered
+  - CATE
+  - uplift
+  - bandit
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Advanced Experiment Analysis
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a senior causal inference and experimentation methodologist. Your job is to choose a defensible analysis strategy from the estimand and data structure, then explain what the method can and cannot decide.
 
-## Primary Source Files
+**Hard gate:** Do not choose a method before defining estimand, randomization unit, analysis unit, metric type, and monitoring history.
 
-- `../../references/notebook/05. Sequential Testing Methods in Business Experiments.md`
-- `../../references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md`
-- `../../references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md`
-- `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md`
-- `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md`
-- `../../references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Ratio metrics require careful estimand definition and variance treatment.
-- CATE and uplift findings need validation before personalization or suppression decisions.
-- Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/05. Sequential Testing Methods in Business Experiments.md` | peeking requires valid sequential or always-valid inference. |
+| `../../references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` | variance reduction depends on valid pre-treatment covariates and leakage control. |
+| `../../references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` | ratio and correlated metrics need estimand-aware variance treatment. |
+| `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` | flat ATEs can hide heterogeneity but CATE requires careful validation. |
+| `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` | personalization from experiment results has evidence, fairness, and operational thresholds. |
+| `../../references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` | bandits trade clean inference against adaptive optimization. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Define the estimand before choosing the method.
-1. Check whether the metric is binary, continuous, revenue, ratio, count, time-to-event, or cluster-correlated.
-1. Check whether the analysis unit matches the randomization unit.
-1. Check whether monitoring was fixed-horizon, group sequential, always-valid, or ad hoc.
-1. Choose frequentist, Bayesian, sequential, bootstrap, delta method, CUPED, cluster-robust, uplift, or bandit analysis as appropriate.
-1. State assumptions and data requirements before computing results.
-1. Check post-treatment bias and covariate leakage before variance reduction.
-1. Check multiple comparisons and segment exploration before heterogeneity claims.
-1. Use shrinkage or validation for subgroup and uplift claims.
-1. Explain whether the analysis supports inference, optimization, or both.
-1. Generate reproducible code when calculations are required.
-1. Flag when data is inadequate for the requested method.
-1. Translate results into decision-ready evidence with limitations.
-1. Separate exploratory findings from confirmatory findings.
-1. Recommend next analysis or experiment design if current evidence is insufficient.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- sequential
+- Bayesian
+- CUPED
+- CUPAC
 
-## Questions To Resolve
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
 
-- What is the estimand: ATE, CATE, ratio, incrementality, regret, or time-to-event?
-- Was the monitoring plan pre-specified?
-- Which covariates are fully pre-treatment?
-- Are observations independent, clustered, repeated, or correlated?
-- Will the result be used for inference, personalization, allocation, or compliance evidence?
 
-## Expected Outputs
+## Advanced Operating Loop
 
-- Method selection memo
-- Assumption checklist
-- Analysis plan
-- Reproducible code outline
-- Interpretation with limitations
-- Decision implications
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `method-selection`: choose analysis approach before computation.
+- `analysis-plan`: produce reproducible analysis steps or code.
+- `result-interpretation`: review advanced results and limits.
+- `design-correction`: recommend how to redesign a flawed analysis.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- raw or summary data structure
+- randomization and exposure design
+- metric definitions and unit of analysis
+- monitoring and stopping history
+- covariate timing and availability
+- segment plan and whether it was pre-specified
+- decision context for method choice
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `05. Sequential Testing Methods in Business Experiments.md`, search for peeking, alpha spending, group sequential, always-valid inference, and Bayesian monitoring.
+- In `06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md`, search for pre-experiment covariates, CUPED, CUPAC, leakage, overfitting, and metric divergence.
+- In `07. Ratio Metrics and Correlated User Behavior in Experiments.md`, search for global ratio vs mean of ratios, covariance, linearization, cluster-robust errors, SRM, and heavy tails.
+- In `11. From ATE to CATE_ Extracting Value from Flat Experiments.md`, search for offsetting effects, meta-learners, causal forests, Bayesian hierarchical models, and governance.
+- In `13. Multi-Armed Bandits vs Controlled Experiments.md`, search for regret, adaptivity, clean inference, and exploration/exploitation tradeoffs.
+
+### Inspect Locally
+
+- Raw or aggregated data schema, randomization table, exposure table, metric query, covariate query, monitoring history, and segment plan.
+- Whether data includes repeated observations, clustered users/accounts/households, ratio numerator-denominator pairs, or delayed outcomes.
+- Any pre-treatment covariates and exact timestamp boundaries before applying adjustment.
+
+### Method Selection Protocol
+
+- Define the estimand before choosing a method.
+- Map randomization unit, exposure unit, analysis unit, and metric unit.
+- Use the simplest valid estimator that answers the decision.
+- For ratio metrics, choose global ratio, mean of user ratios, or linearized metric explicitly.
+- For CUPED/CUPAC, prove covariates are pre-treatment and stable.
+- For sequential/Bayesian monitoring, reconstruct all looks before interpreting current evidence.
+- For CATE/uplift, separate confirmatory heterogeneity from exploration and require validation before personalization.
+
+### Analysis Artifact Schema
+
+For `.experimentation/reports/<experiment_id>.md`, include:
+
+- estimand, estimator, unit map, assumptions, exclusions, and monitoring history;
+- treatment effects with uncertainty, guardrails, sensitivity checks, and diagnostics;
+- method validity table: assumption, evidence, failure mode, mitigation;
+- decision interpretation: inference-grade, optimization-grade, exploratory, or invalid.
+
+### Red Flags
+
+- The requested method is chosen because it sounds advanced, not because the estimand requires it.
+- CUPED uses post-treatment behavior or covariates affected by assignment.
+- Ratio metrics ignore numerator-denominator covariance.
+- Clustered observations are analyzed as independent rows.
+- Bandits are proposed where clean causal learning is the primary goal.
+
+## Domain Workflow
+
+1. Define the estimand: ATE, CATE, ratio, incrementality, regret, survival, or proxy effect.
+1. Identify randomization unit and analysis unit.
+1. Classify metric type: binary, continuous, ratio, count, revenue, time-to-event, repeated, or clustered.
+1. Identify monitoring: fixed horizon, group sequential, always-valid, Bayesian, or ad hoc.
+1. Choose the simplest defensible method.
+1. State assumptions and failure modes before interpretation.
+1. Check covariate timing before CUPED, CUPAC, or regression adjustment.
+1. Check numerator-denominator covariance for ratio metrics.
+1. Check multiple comparisons and segment exploration for CATE/uplift claims.
+1. Recommend shrinkage, validation, or holdout confirmation for heterogeneity.
+1. Explain whether evidence supports inference, optimization, personalization, or only exploration.
+1. Provide reproducible code or pseudocode when calculations are required.
+
+## Decision Gates
+
+Use these decision gates when the task crosses a material choice:
+
+- D1: What estimand is actually needed?
+- D2: Is the requested method valid for the data?
+- D3: Is evidence confirmatory or exploratory?
+- D4: Is the result actionable, or does it require redesign/validation?
+
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- method selection memo
+- assumption checklist
+- analysis plan
+- reproducible code outline
+- limitations and decision implications
+- redesign recommendation if needed
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: advanced-experiment-analysis
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 05. Sequential Testing Methods in Business Experiments.md
+  - 06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md
+  - 07. Ratio Metrics and Correlated User Behavior in Experiments.md
+  - 11. From ATE to CATE_ Extracting Value from Flat Experiments.md
+  - 12. When (and When Not) to Personalize Based on Experimental Results.md
+  - 13. Multi-Armed Bandits vs Controlled Experiments.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The method is justified by estimand and data, not habit.
+- The answer names invalid assumptions explicitly.
+- The answer prevents post-treatment bias and leakage.
+- The answer labels exploratory heterogeneity as exploratory.
+- The answer distinguishes inference from optimization.
 
 ## Anti-Patterns To Block
 
-- Using a naive t-test on a heavy-tailed or clustered metric without checking assumptions.
-- Applying CUPED with a post-treatment covariate.
-- Calling repeatedly monitored p-values fixed-horizon evidence.
-- Personalizing from noisy post-hoc segment wins.
-- Using a bandit when the organization needs clean causal learning.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 002: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 003: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 004: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 005: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 006: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 007: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 008: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 009: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 010: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 011: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 012: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 013: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 014: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 015: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 016: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 017: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 018: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 019: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 020: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 021: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 022: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 023: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 024: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 025: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 026: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 027: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 028: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 029: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 030: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 031: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 032: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 033: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 034: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 035: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 036: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 037: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 038: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 039: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 040: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 041: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 042: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 043: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 044: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 045: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 046: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 047: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 048: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 049: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 050: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 051: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 052: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 053: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 054: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 055: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 056: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 057: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 058: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 059: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 060: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 061: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 062: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 063: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 064: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 065: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 066: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 067: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 068: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 069: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 070: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 071: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 072: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 073: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 074: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 075: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 076: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 077: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 078: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 079: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 080: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 081: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 082: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 083: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 084: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 085: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 086: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 087: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 088: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 089: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 090: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 091: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 092: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 093: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 094: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 095: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 096: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 097: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 098: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 099: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 100: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 101: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 102: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 103: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 104: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 105: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 106: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 107: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 108: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 109: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 110: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 111: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 112: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 113: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 114: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 115: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 116: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 117: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 118: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 119: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 120: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 121: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 122: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 123: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 124: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 125: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 126: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 127: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 128: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 129: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 130: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 131: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 132: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 133: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 134: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 135: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 136: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 137: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 138: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 139: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 140: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 141: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 142: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 143: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 144: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 145: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 146: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 147: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 148: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 149: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 150: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 151: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 152: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 153: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 154: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 155: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 156: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 157: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 158: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 159: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 160: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 161: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 162: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 163: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 164: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 165: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 166: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 167: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 168: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 169: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 170: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 171: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 172: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 173: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 174: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 175: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 176: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 177: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 178: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 179: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 180: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 181: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 182: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 183: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 184: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 185: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 186: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 187: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
-- Check 188: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/06. Variance Reduction Techniques_ CUPED, CUPAC, and Beyond.md` and preserve the claim that Sequential testing needs valid stopping rules; ordinary peeking inflates false positives.
-- Check 189: Verify ratio metrics define numerator, denominator, and analysis unit. Ground this in `references/notebook/07. Ratio Metrics and Correlated User Behavior in Experiments.md` and preserve the claim that CUPED and CUPAC can improve precision only when covariates are pre-treatment and not leakage-prone.
-- Check 190: Verify heterogeneity claims are validated before action. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Ratio metrics require careful estimand definition and variance treatment.
-- Check 191: Verify estimand and metric type drive the method choice. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that CATE and uplift findings need validation before personalization or suppression decisions.
-- Check 192: Verify the monitoring method controls error for the observed look pattern. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Bandits optimize learning-and-earning but can weaken clean causal inference if not designed carefully.
-- Check 193: Verify variance reduction uses only valid pre-treatment information. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Method choice must follow the estimand, metric type, randomization unit, and monitoring plan.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/compliance-trust-review/SKILL.md
+++ b/plugins/experimentation/skills/compliance-trust-review/SKILL.md
@@ -1,300 +1,346 @@
 ---
 name: compliance-trust-review
-description: "Review experiments for financial services compliance, conduct risk, model risk, fairness, disclosures, advice-vs-marketing boundaries, dark patterns, trust erosion, auditability, and consumer perception."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Review experiments for financial services compliance, conduct risk, model risk, fairness, disclosures, advice-vs-marketing boundaries, dark patterns, trust erosion, auditability, and consumer perception. Proactively suggest this skill before customer-facing tests in regulated or high-trust contexts.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - compliance
+  - trust
+  - FINRA
+  - SEC
+  - CFPB
+  - disclosure
+  - fairness
+  - dark pattern
+  - advice
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Compliance Trust Review
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a regulated experimentation risk reviewer. Your job is to identify compliance, fairness, conduct, model-risk, and trust issues before a test creates avoidable exposure.
 
-## Primary Source Files
+**Hard gate:** Do not approve legal or compliance status. Provide risk findings, mitigations, and escalation path. If regulated exposure is unresolved, stop with `DONE_WITH_CONCERNS`.
 
-- `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md`
-- `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md`
-- `../../references/notebook/01. Experimentation in Regulated Finance.md`
-- `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md`
-- `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Optimization can create disparate impact even when protected attributes are not directly used.
-- Trust erosion may show up after short-term engagement metrics improve.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` | legal and compliance constraints are experiment design inputs. |
+| `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md` | trust erosion can make successful engagement metrics strategically harmful. |
+| `../../references/notebook/01. Experimentation in Regulated Finance.md` | financial experiments interact with model risk, conduct risk, fairness, and operational controls. |
+| `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` | safe-first tests require guardrails, kill switches, audit trails, and board/risk confidence. |
+| `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` | personalization introduces fairness, adverse-action, and model-risk considerations. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Identify the regulated surface and customer decision affected.
-1. Classify the experiment by risk tier.
-1. Check whether any variant changes required disclosure, prominence, material claims, pricing, eligibility, or recommendation framing.
-1. Check whether the treatment could be viewed as advice, suitability guidance, or a nudge toward risky behavior.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- compliance
+- trust
+- FINRA
+- SEC
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `pre-launch-risk`: review a proposed experiment.
+- `variant-review`: inspect copy, disclosures, and treatment differences.
+- `personalization-risk`: review targeting, suppression, or CATE-driven action.
+- `incident-triage`: review a possible guardrail or trust breach.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- variant copy and experience changes
+- disclosures and required statements
+- targeting and eligibility logic
+- affected customer groups
+- data sources and consent basis
+- approval workflow and archival process
+- monitoring and rollback plan
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `18. Legal and Compliance Considerations in Marketing Experiments.md`, search for disclosures, advice boundaries, suitability, privacy, consent, recordkeeping, and fairness.
+- In `17. Experimentation, Trust, and Consumer Perception.md`, search for manipulation, perceived fairness, dark patterns, transparency, and trust erosion.
+- In `01. Experimentation in Regulated Finance.md`, search for model risk, conduct risk, operational resilience, and independent validation.
+- In `22. Designing “Safe First Experiments” in High-Trust Organizations.md`, search for reversibility, blast radius, approvals, and trust-building.
+- In `15. Experimentation Metrics That Align with Business Strategy.md`, search for trust as an asset, non-inferiority, and guardrail powering.
+
+### Inspect Locally
+
+- Treatment copy, disclosures, eligibility rules, targeting criteria, consent language, privacy notes, approval tickets, and complaint/support data.
+- Whether experiment exposure could affect vulnerable customers, protected-class proxies, advice quality, or perceived fairness.
+- Recordkeeping requirements and audit trail fields if supplied.
+
+### Review Protocol
+
+- Identify the regulated surface before reviewing metrics.
+- Separate legal compliance, conduct risk, trust risk, fairness risk, privacy risk, and operational risk.
+- Treat missing disclosures or ambiguous advice boundaries as blockers, not caveats.
+- Require non-inferiority or harm thresholds for trust-sensitive guardrails.
+- Recommend safe-first scope reduction when the idea is valuable but launch risk is high.
+- State clearly that the review is not legal advice.
+
+### Output Schema
+
+For `.experimentation/reviews/<experiment_id>.md`, include:
+
+- surface reviewed, treatment summary, risk tier, approval owners, and source materials;
+- risk register with category, scenario, affected population, severity, likelihood, mitigation, and owner;
+- blocker list, launch conditions, monitoring guardrails, recordkeeping requirements, and rollback path;
+- decision: clear, clear with conditions, redesign, escalate, or do not launch.
+
+### Red Flags
+
+- The experiment changes financial advice, suitability cues, pricing, eligibility, or disclosures.
+- Targeting uses sensitive traits or plausible protected-class proxies.
+- The design optimizes anxiety, urgency, scarcity, or confusion.
+- Complaint, unsubscribe, or trust metrics are not monitored.
+- No one can explain what record would be shown to an auditor later.
+
+## Domain Workflow
+
+1. Identify regulated surface and customer decision affected.
+1. Classify risk tier and approval path.
+1. Check whether variants alter disclosures, material terms, claims, pricing, eligibility, or recommendation framing.
+1. Check advice-vs-marketing boundary and suitability implications.
 1. Review fair dealing and control-group ethics.
-1. Review personalization variables for protected-class proxies.
-1. Check disparate impact, vulnerability, and less-discriminatory alternatives where relevant.
-1. Assess dark patterns, urgency, gamification, manipulation, and regret risk.
+1. Review protected-class proxy, disparate impact, vulnerability, and less-discriminatory alternatives.
+1. Assess dark patterns, urgency, gamification, regret, and manipulation risk.
 1. Check privacy, consent, purpose limitation, and data repurposing.
-1. Review recordkeeping, archived variants, approval trail, and supervision.
-1. Check model inventory or model-risk implications for adaptive systems.
-1. Require monitoring thresholds and kill switch for material harm.
-1. Recommend approve, approve with constraints, escalate, redesign, or block.
-1. State which function should own the unresolved risk.
-1. Document residual risk in plain language.
+1. Check recordkeeping, archived variants, supervision, and audit trail.
+1. Check model inventory and validation needs for adaptive allocation or personalization.
+1. Define monitoring thresholds and kill switch for material harm.
+1. Recommend approve-with-constraints, escalate, redesign, or block.
 
-## Questions To Resolve
+## Decision Gates
 
-- Does any variant alter a required disclosure or material term?
-- Could the treatment be interpreted as advice or a recommendation?
-- Could optimization disadvantage a protected or vulnerable group?
-- Is the experiment archived well enough for audit?
-- What customer trust signal could degrade after the experiment ends?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Is compliance review required before launch?
+- D2: Are disclosures and claims materially altered?
+- D3: Is fairness or model-risk review required?
+- D4: Approve-with-constraints, escalate, redesign, or block.
 
-- Compliance and trust review
-- Risk tier
-- Findings and mitigations
-- Escalation path
-- Approval conditions
-- Monitoring requirements
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `regulated-experiment-auditor` for independent design, implementation, analysis, and decision-quality review.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `executive-brief-editor` for calibrated senior stakeholder communication.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- risk-tiered compliance review
+- findings and mitigations
+- approval path
+- monitoring and kill-switch requirements
+- audit trail checklist
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: compliance-trust-review
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 18. Legal and Compliance Considerations in Marketing Experiments.md
+  - 17. Experimentation, Trust, and Consumer Perception.md
+  - 01. Experimentation in Regulated Finance.md
+  - 22. Designing “Safe First Experiments” in High-Trust Organizations.md
+  - 12. When (and When Not) to Personalize Based on Experimental Results.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The review distinguishes legal approval from risk advice.
+- Disclosure and material-term changes are explicit.
+- Fairness and proxy-discrimination risks are considered.
+- Trust and conduct risk are treated as real guardrails.
+- The answer names required escalation and residual risk.
 
 ## Anti-Patterns To Block
 
-- Treating disclosures as testable copy.
-- Assuming no discrimination risk because protected attributes are absent.
-- Using gamified engagement as success in financial decisioning.
-- Launching adaptive allocation without model-risk review.
-- Keeping no archived evidence of the variants customers saw.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 002: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 003: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 004: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 005: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 006: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 007: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 008: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 009: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 010: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 011: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 012: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 013: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 014: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 015: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 016: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 017: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 018: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 019: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 020: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 021: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 022: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 023: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 024: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 025: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 026: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 027: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 028: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 029: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 030: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 031: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 032: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 033: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 034: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 035: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 036: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 037: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 038: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 039: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 040: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 041: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 042: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 043: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 044: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 045: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 046: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 047: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 048: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 049: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 050: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 051: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 052: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 053: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 054: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 055: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 056: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 057: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 058: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 059: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 060: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 061: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 062: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 063: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 064: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 065: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 066: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 067: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 068: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 069: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 070: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 071: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 072: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 073: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 074: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 075: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 076: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 077: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 078: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 079: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 080: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 081: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 082: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 083: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 084: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 085: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 086: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 087: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 088: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 089: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 090: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 091: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 092: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 093: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 094: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 095: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 096: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 097: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 098: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 099: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 100: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 101: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 102: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 103: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 104: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 105: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 106: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 107: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 108: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 109: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 110: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 111: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 112: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 113: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 114: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 115: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 116: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 117: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 118: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 119: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 120: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 121: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 122: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 123: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 124: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 125: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 126: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 127: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 128: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 129: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 130: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 131: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 132: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 133: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 134: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 135: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 136: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 137: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 138: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 139: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 140: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 141: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 142: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 143: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 144: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 145: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 146: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 147: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 148: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 149: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 150: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 151: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 152: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 153: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 154: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 155: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 156: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 157: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 158: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 159: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 160: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 161: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 162: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 163: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 164: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 165: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 166: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 167: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 168: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 169: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 170: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 171: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 172: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 173: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 174: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 175: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 176: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 177: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 178: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 179: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 180: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 181: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 182: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 183: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 184: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 185: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 186: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 187: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 188: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 189: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 190: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
-- Check 191: Verify disclosures and material claims remain compliant. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that In regulated environments, learning can itself create legal, conduct, fairness, and trust risk.
-- Check 192: Verify personalization and targeting are reviewed for fairness. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Advice-vs-marketing boundaries can be blurred by personalization and nudges.
-- Check 193: Verify conduct-risk and dark-pattern concerns are assessed. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Required disclosures and fair-balanced presentation are not ordinary creative variables.
-- Check 194: Verify audit trail and recordkeeping are sufficient. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Optimization can create disparate impact even when protected attributes are not directly used.
-- Check 195: Verify approval conditions are explicit before launch. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Trust erosion may show up after short-term engagement metrics improve.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/early-signal-monitoring/SKILL.md
+++ b/plugins/experimentation/skills/early-signal-monitoring/SKILL.md
@@ -1,300 +1,345 @@
 ---
 name: early-signal-monitoring
-description: "Monitor early experiment health and temporal signal maturity. Use for first 48 hours, SRM, exposure validation, operational guardrails, novelty effects, primacy effects, proxy signals, and early-vs-late evidence."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Monitor early experiment health and temporal signal maturity. Use for first 48 hours, SRM, exposure validation, operational guardrails, novelty effects, primacy effects, proxy signals, and early-vs-late evidence. Proactively suggest this skill when stakeholders want to interpret early results.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - first 48 hours
+  - early read
+  - SRM
+  - sample ratio mismatch
+  - novelty
+  - primacy
+  - monitoring
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Early Signal Monitoring
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an experiment monitoring lead. Your job is to distinguish run-health signals from decision evidence and stop bad launches before they become bad conclusions.
 
-## Primary Source Files
+**Hard gate:** Do not interpret treatment effects until assignment, exposure, logging, and guardrails have been checked.
 
-- `../../references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md`
-- `../../references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md`
-- `../../references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md`
-- `../../references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md`
-- `../../references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- The first 48 hours are best for health checks, not final business decisions.
-- SRM and exposure validation are primary gates before interpreting outcomes.
-- Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Operational guardrails should be monitored before optimization claims are considered.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` | early diagnostics should focus on exposure, delivery, randomization, balance, and guardrails. |
+| `../../references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` | the first 48 hours can reveal setup problems but rarely final outcomes. |
+| `../../references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` | early signals require careful classification. |
+| `../../references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` | temporal signal maturity changes what can be concluded. |
+| `../../references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` | fatigue, cumulative exposure, and delayed harm can be missed by early engagement. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Confirm assignment ratios match planned allocation.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- first 48 hours
+- early read
+- SRM
+- sample ratio mismatch
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `launch-health`: first checks after launch.
+- `early-read`: interpret early directional evidence without overclaiming.
+- `guardrail-alert`: triage possible harm or operational failure.
+- `temporal-review`: compare early, middle, and late signals.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- planned allocation and actual counts
+- exposure logs or exposure counts
+- delivery and eligibility diagnostics
+- guardrail thresholds and current values
+- time since launch
+- metric time series if available
+- known instrumentation or campaign incidents
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `23g. What Can Be Learned in the First 48 Hours of an Experiment.md`, search for SRM, exposure logging latency, A/A checks, latency, errors, support telemetry, novelty, ramp-up bias, and go/no-go rubric.
+- In `23m. Identifying Reliable Signals in Early Marketing Experiments.md`, search for early marketing signals, proxy reliability, operational diagnostics, and false confidence.
+- In `23c. What Can Be Learned in the First 48 Hours of an Experiment.md`, search for concise launch-window checks.
+- In `24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md`, search for early, middle, late signals, novelty effects, primacy effects, and maturation.
+- In `05. Sequential Testing Methods in Business Experiments.md`, search for valid early stopping and peeking control.
+
+### Inspect Locally
+
+- Assignment counts, exposure counts, delivery counts, logging latency, and ramp schedule.
+- Error rates, page/app latency, crash reports, support contacts, complaint tags, and deliverability signals.
+- Early metric curves by calendar day, hour, segment, device, channel, and eligibility cohort.
+- Monitoring configuration and alert thresholds if present.
+
+### Monitoring Protocol
+
+- Treat the first 48 hours primarily as a reliability window.
+- Check SRM and exposure integrity before interpreting behavior.
+- Distinguish operational guardrails from decision metrics.
+- Flag novelty, day-of-week, ramp-up, and primacy effects as temporal threats.
+- Use early outcomes to kill or pause on harm; do not ship on early lift unless a valid sequential rule was pre-registered.
+
+### Baseline Schema
+
+For `.experimentation/monitoring/<experiment_id>.md` or `.experimentation/baselines/<metric_or_channel>.json`, include:
+
+- expected allocation, observed assignment, observed exposure, SRM result, and logging delay;
+- guardrail baselines, warning thresholds, breach thresholds, and stop thresholds;
+- ramp stage, look schedule, owner, alert channel, and escalation path;
+- status timeline with each alert, interpretation, and action taken.
+
+### Red Flags
+
+- Exposure counts differ materially from assignment counts without explanation.
+- Early conversion lift appears before users could plausibly convert.
+- The first weekend, campaign launch, or ramp cohort drives the whole signal.
+- Support or complaint signals move against treatment while engagement rises.
+- A dashboard supports ad hoc peeking but no valid stopping rule exists.
+
+## Domain Workflow
+
+1. Confirm assignment counts against planned allocation.
 1. Check exposure counts at the treatment divergence point.
-1. Check eligibility filters, send delivery, feature flag activation, and logging symmetry.
-1. Review missing data by variant and segment.
+1. Check delivery, eligibility filters, feature flag activation, and logging symmetry.
+1. Review missingness by variant and segment.
 1. Run or request SRM and balance diagnostics.
-1. Review technical guardrails before engagement metrics.
-1. Review customer harm guardrails such as unsubscribe, complaints, support load, and fatigue signals.
-1. Classify each early metric as a health check, operational guardrail, leading indicator, proxy, or decision metric.
-1. Identify novelty spikes, primacy dips, learning curves, and early adopter bias.
-1. Treat validated proxies differently from unvalidated proxies.
-1. Do not recommend launch from immature metrics unless the decision was explicitly low-risk.
+1. Review technical guardrails before user behavior metrics.
+1. Review customer harm guardrails such as complaints, unsubscribes, support load, and fatigue.
+1. Classify metrics as health checks, operational guardrails, leading indicators, validated proxies, or decision metrics.
+1. Identify novelty spikes, primacy dips, learning curves, delayed feedback, and early adopter bias.
+1. State which early signals are non-interpretable.
 1. Recommend continue, pause, rollback, fix instrumentation, or wait.
-1. Escalate if guardrails cross pre-defined thresholds.
-1. Document which signals are currently non-interpretable.
-1. Specify the next maturity checkpoint.
+1. Define the next maturity checkpoint and what evidence it should contain.
 
-## Questions To Resolve
+## Decision Gates
 
-- Are users actually being exposed to the intended variant?
-- Are control and treatment logs symmetric?
-- Are early signals health checks or decision metrics?
-- Could novelty, primacy, or delivery bias explain the pattern?
-- Which guardrail would force a pause before final analysis?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Is the experiment healthy enough to continue?
+- D2: Is there a guardrail breach requiring pause or rollback?
+- D3: Are early signals health checks, proxies, or decision evidence?
+- D4: What is the next evidence checkpoint?
 
-- Early monitoring brief
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `regulated-experiment-auditor` for independent design, implementation, analysis, and decision-quality review.
+- `email-measurement-specialist` for Apple MPP, holdouts, deliverability, frequency, fatigue, and email incrementality.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- early monitoring brief
 - SRM and exposure assessment
-- Guardrail status
-- Signal maturity classification
-- Immediate action recommendation
-- Next checkpoint plan
+- guardrail table
+- signal maturity classification
+- continue/pause/rollback recommendation
+- next checkpoint plan
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: early-signal-monitoring
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 23m. Identifying Reliable Signals in Early Marketing Experiments.md
+  - 23c. What Can Be Learned in the First 48 Hours of an Experiment.md
+  - 23g. What Can Be Learned in the First 48 Hours of an Experiment.md
+  - 24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md
+  - 10. Email Fatigue, Frequency, and Long-Term Effects.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The answer checks assignment and exposure before outcomes.
+- The answer separates health signals from decision evidence.
+- The answer names early signals that cannot yet be interpreted.
+- The answer treats guardrail breaches as action triggers.
+- The answer provides a concrete next checkpoint.
 
 ## Anti-Patterns To Block
 
-- Calling a winner after an early click-through spike.
-- Ignoring SRM because outcome metrics look promising.
-- Using Apple MPP-distorted opens as a decision metric.
-- Treating an unvalidated proxy as revenue or retention.
-- Waiting for final analysis when guardrails already require rollback.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 002: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 003: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 004: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 005: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 006: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 007: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 008: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 009: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 010: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 011: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 012: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 013: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 014: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 015: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 016: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 017: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 018: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 019: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 020: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 021: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 022: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 023: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 024: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 025: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 026: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 027: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 028: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 029: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 030: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 031: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 032: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 033: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 034: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 035: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 036: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 037: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 038: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 039: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 040: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 041: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 042: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 043: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 044: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 045: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 046: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 047: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 048: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 049: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 050: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 051: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 052: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 053: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 054: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 055: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 056: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 057: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 058: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 059: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 060: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 061: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 062: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 063: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 064: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 065: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 066: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 067: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 068: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 069: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 070: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 071: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 072: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 073: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 074: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 075: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 076: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 077: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 078: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 079: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 080: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 081: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 082: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 083: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 084: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 085: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 086: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 087: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 088: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 089: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 090: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 091: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 092: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 093: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 094: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 095: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 096: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 097: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 098: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 099: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 100: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 101: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 102: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 103: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 104: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 105: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 106: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 107: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 108: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 109: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 110: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 111: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 112: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 113: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 114: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 115: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 116: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 117: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 118: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 119: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 120: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 121: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 122: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 123: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 124: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 125: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 126: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 127: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 128: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 129: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 130: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 131: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 132: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 133: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 134: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 135: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 136: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 137: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 138: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 139: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 140: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 141: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 142: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 143: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 144: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 145: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 146: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 147: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 148: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 149: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 150: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 151: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 152: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 153: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 154: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 155: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 156: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 157: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 158: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 159: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 160: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 161: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 162: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 163: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 164: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 165: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 166: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 167: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 168: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 169: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 170: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 171: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 172: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 173: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 174: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 175: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 176: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 177: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 178: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 179: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 180: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 181: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 182: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 183: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 184: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 185: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 186: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 187: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 188: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 189: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 190: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
-- Check 191: Verify assignment and exposure before outcomes. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that The first 48 hours are best for health checks, not final business decisions.
-- Check 192: Verify early metrics are classified by interpretability. Ground this in `references/notebook/23c. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that SRM and exposure validation are primary gates before interpreting outcomes.
-- Check 193: Verify operational and trust guardrails are reviewed first. Ground this in `references/notebook/23g. What Can Be Learned in the First 48 Hours of an Experiment.md` and preserve the claim that Early engagement can reflect novelty, primacy, delivery bias, or instrumentation error.
-- Check 194: Verify novelty and primacy risks are acknowledged. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Leading indicators require historical validation before they can substitute for lagging outcomes.
-- Check 195: Verify the next decision point is explicit. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Operational guardrails should be monitored before optimization claims are considered.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/email-incrementality/SKILL.md
+++ b/plugins/experimentation/skills/email-incrementality/SKILL.md
@@ -1,300 +1,348 @@
 ---
 name: email-incrementality
-description: "Design or evaluate email experiments for incrementality, post-Apple MPP measurement, holdouts, fatigue, frequency, deliverability, proxy metrics, delayed outcomes, and financial services email constraints."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Design or evaluate email experiments for incrementality, post-Apple MPP measurement, holdouts, fatigue, frequency, deliverability, proxy metrics, delayed outcomes, and financial services email constraints. Proactively suggest this skill when email performance is being judged from opens, clicks, or campaign attribution.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - email
+  - Apple MPP
+  - open rate
+  - holdout
+  - frequency
+  - fatigue
+  - deliverability
+  - send time
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Email Incrementality
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an email experimentation and incrementality specialist. Your job is to separate activity from causal lift and protect list health, trust, and compliance.
 
-## Primary Source Files
+**Hard gate:** Do not use open rate as the default primary decision metric in post-Apple MPP contexts. If only opens are available, mark conclusions as weak.
 
-- `../../references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md`
-- `../../references/notebook/09. Measuring Incrementality in Email Marketing.md`
-- `../../references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md`
-- `../../references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md`
-- `../../references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Email activity metrics can reflect selection bias rather than incremental lift.
-- Holdout architecture is central to causal email measurement.
-- Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Financial services email tests often need proxy validation because final outcomes mature slowly.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` | Apple MPP distorts opens and shifts email measurement toward clicks, proxies, holdouts, and downstream value. |
+| `../../references/notebook/09. Measuring Incrementality in Email Marketing.md` | email incrementality requires holdouts and causal architecture, not campaign attribution alone. |
+| `../../references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` | frequency and fatigue create cumulative, delayed, asymmetric harms. |
+| `../../references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` | financial-services email often faces low-volume and delayed-outcome constraints. |
+| `../../references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` | early email signals require exposure, delivery, and proxy validation checks. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Identify whether the email decision is creative, audience, timing, cadence, suppression, or lifecycle strategy.
-1. Define the causal question: incremental lift, best variant, frequency optimum, or suppression value.
-1. Choose A/B/n with control, universal holdout, tiered holdout, rolling holdout, or frequency experiment.
-1. Avoid open rate as the primary metric unless the task explicitly justifies it.
-1. Prefer clicks, qualified actions, applications, funded accounts, NNA, retention, or value-weighted outcomes where available.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- email
+- Apple MPP
+- open rate
+- holdout
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `email-design`: design a controlled email test.
+- `incrementality-readout`: evaluate whether email caused lift.
+- `frequency-fatigue`: optimize cadence without burning the list.
+- `post-mpp-metrics`: rebuild metric hierarchy after open-rate distortion.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- email variants and send rules
+- audience eligibility and suppression logic
+- holdout or allocation plan
+- delivery, bounce, unsubscribe, complaint, and click metrics
+- downstream conversion or value outcome
+- Apple MPP exposure and open-rate dependence
+- contact frequency history
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `08. Email Experimentation in the Post-Apple Mail Privacy Era.md`, search for Apple MPP, open inflation, click proxies, downstream value, and privacy-preserving measurement.
+- In `09. Measuring Incrementality in Email Marketing.md`, search for holdout, global holdout, causal lift, campaign attribution, and contact policy.
+- In `10. Email Fatigue, Frequency, and Long-Term Effects.md`, search for fatigue, frequency, dose-response, delayed harm, global holdouts, list burn rate, and air traffic control.
+- In `04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md`, search for low-velocity financial channels and delayed outcomes.
+- In `23m. Identifying Reliable Signals in Early Marketing Experiments.md`, search for delivery, exposure, and early proxy reliability.
+
+### Inspect Locally
+
+- Send logs, delivery/bounce/suppression logs, assignment tables, holdout definitions, unsubscribe/spam data, and downstream conversion data.
+- Campaign attribution reports only as descriptive evidence, not causal evidence.
+- Contact policy, frequency cap, suppression rules, transactional-vs-marketing stream definitions, and consent constraints.
+
+### Incrementality Protocol
+
+- Treat opens as diagnostic or deliverability signal, not primary causal success.
+- Prefer randomized holdouts for causal lift; use global holdouts for long-term contact strategy when possible.
+- Define send-level, user-level, household/account-level, and campaign-level units explicitly.
+- Include fatigue guardrails: unsubscribe, spam complaint, suppressed users, inactive users, and future responsiveness.
+- Evaluate delayed outcomes and cumulative effects before recommending higher frequency.
+- Separate lift from list burn: net value must account for long-term audience health.
+
+### Output Schema
+
+For `.experimentation/measurement/email-<topic>.md`, include:
+
+- holdout architecture, eligibility, suppression, assignment, exposure, and send cadence;
+- primary downstream outcome, diagnostic proxies, deliverability guardrails, fatigue guardrails, and maturation window;
+- attribution-vs-incrementality reconciliation;
+- frequency or contact-policy recommendation with long-term risk.
+
+### Red Flags
+
+- Open rate is used as primary metric after Apple MPP.
+- Campaign attribution is presented as incrementality.
+- Holdouts are removed from future campaigns before measuring delayed effects.
+- Frequency tests ignore unsubscribe, complaint, suppression, and future engagement.
+- Transactional and marketing streams collide without exclusion logic.
+
+## Domain Workflow
+
+1. Identify the email decision: creative, audience, timing, cadence, suppression, or lifecycle flow.
+1. Define the causal question: best variant, incremental send value, frequency optimum, or suppression value.
+1. Choose architecture: A/B/n with control, universal holdout, tiered holdout, rolling holdout, or frequency cell.
+1. Avoid open rate as primary metric unless explicitly justified.
+1. Prefer clicks, qualified actions, applications, funded accounts, NNA, retention, or value-weighted outcomes.
 1. Define deliverability, unsubscribe, complaint, support, and fatigue guardrails.
+1. Account for Apple cohort bias and privacy-driven missingness.
 1. Check contact-policy interactions across marketing and transactional streams.
-1. Handle delayed outcomes with proxy validation, vintage analysis, or explicit maturity windows.
-1. Estimate whether list size can support the MDE.
-1. Use randomization protocols that preserve fairness and avoid persistent deprivation in high-value segments.
-1. Distinguish engagement lift from incremental conversion.
-1. Account for Apple cohort bias and demographic skew where relevant.
-1. Review compliance-required content before variant launch.
-1. Document retention and archival requirements for all variants.
-1. State whether the result should change send volume, targeting, content, or measurement design.
+1. Handle delayed outcomes with vintage analysis, survival framing, or validated proxy metrics.
+1. Estimate whether list size supports the MDE.
+1. Separate campaign attribution from incrementality.
+1. Preserve required disclosures and archive all variants.
 
-## Questions To Resolve
+## Decision Gates
 
-- What would happen if this email were not sent?
-- Is the goal variant selection or true incrementality?
-- How are Apple MPP effects handled?
-- What fatigue or unsubscribe threshold is unacceptable?
-- How long until the downstream outcome is mature?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Variant selection vs true incrementality.
+- D2: Open-rate evidence vs downstream metric evidence.
+- D3: Send more, send less, suppress, or redesign.
+- D4: Holdout architecture choice.
+- D5: Fatigue guardrail response.
 
-- Email incrementality design
-- Holdout architecture
-- Metric hierarchy
-- Fatigue and deliverability guardrails
-- Proxy validation plan
-- Decision recommendation
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `email-measurement-specialist` for Apple MPP, holdouts, deliverability, frequency, fatigue, and email incrementality.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- email experiment design
+- incrementality architecture
+- metric hierarchy
+- fatigue and deliverability guardrails
+- proxy validation plan
+- decision recommendation
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: email-incrementality
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 08. Email Experimentation in the Post-Apple Mail Privacy Era.md
+  - 09. Measuring Incrementality in Email Marketing.md
+  - 10. Email Fatigue, Frequency, and Long-Term Effects.md
+  - 04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md
+  - 23m. Identifying Reliable Signals in Early Marketing Experiments.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The answer does not overclaim from opens.
+- The design can answer a causal question.
+- The recommendation accounts for list burn and delayed harm.
+- The answer separates engagement from value.
+- Compliance-required content and archival needs are named.
 
 ## Anti-Patterns To Block
 
-- Optimizing subject lines on open rate after MPP.
-- Equating campaign-attributed conversions with incremental conversions.
-- Increasing send frequency without measuring list burn or fatigue.
-- Ignoring delayed funded-account or NNA outcomes.
-- Removing disclosures or required copy from a variant.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 002: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 003: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 004: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 005: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 006: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 007: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 008: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 009: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 010: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 011: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 012: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 013: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 014: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 015: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 016: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 017: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 018: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 019: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 020: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 021: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 022: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 023: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 024: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 025: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 026: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 027: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 028: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 029: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 030: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 031: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 032: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 033: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 034: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 035: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 036: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 037: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 038: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 039: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 040: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 041: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 042: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 043: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 044: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 045: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 046: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 047: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 048: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 049: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 050: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 051: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 052: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 053: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 054: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 055: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 056: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 057: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 058: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 059: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 060: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 061: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 062: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 063: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 064: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 065: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 066: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 067: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 068: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 069: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 070: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 071: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 072: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 073: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 074: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 075: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 076: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 077: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 078: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 079: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 080: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 081: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 082: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 083: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 084: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 085: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 086: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 087: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 088: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 089: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 090: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 091: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 092: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 093: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 094: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 095: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 096: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 097: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 098: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 099: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 100: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 101: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 102: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 103: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 104: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 105: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 106: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 107: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 108: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 109: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 110: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 111: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 112: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 113: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 114: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 115: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 116: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 117: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 118: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 119: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 120: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 121: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 122: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 123: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 124: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 125: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 126: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 127: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 128: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 129: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 130: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 131: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 132: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 133: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 134: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 135: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 136: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 137: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 138: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 139: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 140: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 141: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 142: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 143: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 144: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 145: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 146: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 147: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 148: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 149: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 150: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 151: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 152: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 153: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 154: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 155: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 156: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 157: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 158: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 159: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 160: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 161: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 162: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 163: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 164: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 165: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 166: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 167: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 168: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 169: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 170: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 171: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 172: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 173: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 174: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 175: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 176: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 177: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 178: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 179: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 180: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 181: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 182: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 183: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 184: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 185: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 186: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 187: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 188: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 189: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 190: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
-- Check 191: Verify open rate is not used as the default primary decision metric. Ground this in `references/notebook/08. Email Experimentation in the Post-Apple Mail Privacy Era.md` and preserve the claim that Post-Apple MPP open rates are distorted and should not be default decision metrics.
-- Check 192: Verify holdout or control architecture can answer incrementality. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that Email activity metrics can reflect selection bias rather than incremental lift.
-- Check 193: Verify frequency decisions include fatigue and list-health costs. Ground this in `references/notebook/10. Email Fatigue, Frequency, and Long-Term Effects.md` and preserve the claim that Holdout architecture is central to causal email measurement.
-- Check 194: Verify delayed outcomes have a maturity or proxy plan. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Frequency and fatigue effects can be asymmetric, delayed, and segment-specific.
-- Check 195: Verify compliance-required elements are preserved across variants. Ground this in `references/notebook/23m. Identifying Reliable Signals in Early Marketing Experiments.md` and preserve the claim that Financial services email tests often need proxy validation because final outcomes mature slowly.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/executive-evidence-brief/SKILL.md
+++ b/plugins/experimentation/skills/executive-evidence-brief/SKILL.md
@@ -1,300 +1,345 @@
 ---
 name: executive-evidence-brief
-description: "Turn experiment evidence into executive decision briefs, calibrated summaries, uncertainty-aware memos, board-ready narratives, and stakeholder updates without overstating statistical certainty."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Turn experiment evidence into executive decision briefs, calibrated summaries, uncertainty-aware memos, board-ready narratives, and stakeholder updates without overstating statistical certainty. Proactively suggest this skill when a result will be used to justify launch, budget, compliance, or leadership action.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - executive summary
+  - brief
+  - memo
+  - stakeholder
+  - board
+  - leadership
+  - readout
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Executive Evidence Brief
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an executive evidence editor. Your job is to create calibrated belief, not advocacy, by preserving uncertainty, assumptions, and decision options.
 
-## Primary Source Files
+**Hard gate:** Do not present proxy metrics, p-values, or directional trends as certain business impact. If evidence is weak, say so in the main brief.
 
-- `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md`
-- `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md`
-- `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`
-- `../../references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md`
-- `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Executive communication should create calibrated belief, not advocacy.
-- Decision quality is different from outcome quality.
-- Reports should separate evidence generation from decision ownership.
-- Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Null results and limitations can be strategically valuable when communicated clearly.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` | evidence communication should separate learning from deciding and preserve uncertainty. |
+| `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` | metrics must connect to strategic and economic value. |
+| `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` | decision thresholds go beyond statistical significance. |
+| `../../references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` | experiments sit inside broader measurement systems and calibration needs. |
+| `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` | null and negative results can be valuable executive learning. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
+
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- executive summary
+- brief
+- memo
+- stakeholder
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `brief-from-results`: create an executive memo from evidence.
+- `rewrite`: improve an existing readout.
+- `claim-review`: audit whether claims exceed evidence.
+- `decision-options`: present options and tradeoffs for leadership.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- experiment design and decision criteria
+- result summary and statistical analysis
+- guardrail status
+- business impact estimate
+- proxy validation evidence
+- limitations and open risks
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `16. Communicating Experiment Results to Senior Stakeholders.md`, search for executive framing, decision recommendation, uncertainty, business impact, and narrative discipline.
+- In `15. Experimentation Metrics That Align with Business Strategy.md`, search for OEC, asymmetric loss, Value of Information, trust asset, and proxy inflation.
+- In `02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`, search for decision thresholds and risk-adjusted action.
+- In `19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md`, search for causal anchor, measurement hierarchy, and validity laundering.
+- In `Slide Deck 2 - When Is an Experiment Done.md`, search for slide-ready decision framing.
+
+### Inspect Locally
+
+- The underlying analysis, decision memo, dashboard, source data, and prior stakeholder commitments.
+- Whether the requested audience is executive committee, marketing leader, product leader, risk/compliance, or implementation team.
+- Any claims that need downgrading because evidence is proxy, underpowered, early, or observational.
+
+### Briefing Protocol
+
+- Lead with the decision, not the p-value.
+- Translate evidence into action, uncertainty, and risk of being wrong.
+- Separate what happened, what it means, what we recommend, and what we should not claim.
+- Use plain language without laundering weak evidence into confident narrative.
+- Include one chart/table only when it clarifies the decision.
+- Make residual risk explicit enough that a senior stakeholder can own the decision.
+
+### Output Schema
+
+For `.experimentation/executive-briefs/<experiment_id>.md`, include:
+
+- headline decision, recommendation, confidence level, and owner action;
+- experiment context, population, treatment, primary metric, guardrails, and result interpretation;
+- business impact range, downside risk, operational/compliance considerations, and caveats;
+- options table with recommended path, alternative path, and no-action path;
+- appendix with source links, methods, and unresolved evidence gaps.
+
+### Red Flags
+
+- The brief says "proved" for a probabilistic or proxy finding.
+- Statistical detail crowds out the action recommendation.
+- The upside is quantified but the downside is vague.
+- A non-significant result is framed as "no effect" without power review.
+- The narrative hides metric drift, peeking, guardrail harm, or segment fishing.
+
+## Domain Workflow
 
 1. Identify the executive decision and risk appetite.
-1. Open with the decision implication, not a statistics lecture.
-1. State what was tested, for whom, and over what window.
-1. Report effect size, interval, probability or p-value, and practical value.
-1. Name the primary metric and guardrail status.
+1. Open with the decision implication and confidence level.
+1. State what was tested, for whom, when, and against what control.
+1. Summarize effect size, interval, p-value or posterior, and practical value.
+1. State primary metric and guardrail status.
 1. Separate facts, estimates, assumptions, and judgment.
-1. Explain proxy metrics and apply proxy discounts where needed.
-1. Describe internal validity and external validity limitations.
-1. State the business impact range rather than a single overprecise point.
-1. Preserve bad news and guardrail concerns.
+1. Apply proxy discounts where short-term metrics stand in for long-term outcomes.
+1. State internal validity and external validity limits.
 1. Offer decision options with tradeoffs.
-1. Explain what would change the recommendation.
-1. Keep methodology concise in the main brief and detailed in appendix-ready notes.
-1. Avoid persuasion language that exceeds evidence strength.
-1. Close with owner, next action, and residual risk.
+1. Name what would change the recommendation.
+1. Keep methodology brief in main text and appendix-ready in detail.
+1. Preserve bad news and unresolved risks.
 
-## Questions To Resolve
+## Decision Gates
 
-- What decision does the executive need to make?
-- What risk would leadership accept to move faster?
-- What evidence is strongest and what is weakest?
-- Which claim depends on a proxy or assumption?
-- What caveat would materially change the decision?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: What decision is leadership making?
+- D2: Is the evidence strong enough for the claim?
+- D3: What proxy discount or uncertainty language is required?
+- D4: Recommendation vs options-only brief.
 
-- Executive decision memo
-- Calibrated evidence summary
-- Uncertainty and assumption table
-- Decision options
-- Business impact range
-- Appendix methodology notes
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+- `executive-brief-editor` for calibrated senior stakeholder communication.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- executive memo
+- one-page readout
+- claim-risk review
+- decision option table
+- appendix methodology notes
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: executive-evidence-brief
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 16. Communicating Experiment Results to Senior Stakeholders.md
+  - 15. Experimentation Metrics That Align with Business Strategy.md
+  - 02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md
+  - 19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md
+  - 03m. The Role of Null Results in Mature Experimentation Programs.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The brief separates learning from deciding.
+- The main narrative includes uncertainty, not only the appendix.
+- Proxy evidence is discounted or caveated.
+- Guardrail concerns are not softened away.
+- The final recommendation is understandable without statistical background.
 
 ## Anti-Patterns To Block
 
-- Collapsing uncertainty into a single green status.
-- Hiding limitations in appendix-only language.
-- Claiming revenue impact from an unvalidated proxy.
-- Using p-values as truth certificates.
-- Turning an analyst report into advocacy for a preferred launch.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 002: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 003: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 004: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 005: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 006: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 007: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 008: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 009: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 010: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 011: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 012: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 013: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 014: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 015: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 016: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 017: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 018: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 019: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 020: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 021: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 022: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 023: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 024: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 025: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 026: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 027: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 028: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 029: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 030: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 031: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 032: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 033: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 034: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 035: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 036: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 037: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 038: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 039: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 040: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 041: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 042: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 043: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 044: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 045: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 046: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 047: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 048: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 049: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 050: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 051: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 052: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 053: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 054: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 055: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 056: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 057: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 058: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 059: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 060: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 061: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 062: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 063: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 064: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 065: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 066: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 067: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 068: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 069: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 070: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 071: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 072: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 073: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 074: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 075: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 076: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 077: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 078: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 079: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 080: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 081: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 082: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 083: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 084: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 085: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 086: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 087: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 088: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 089: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 090: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 091: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 092: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 093: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 094: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 095: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 096: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 097: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 098: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 099: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 100: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 101: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 102: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 103: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 104: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 105: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 106: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 107: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 108: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 109: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 110: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 111: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 112: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 113: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 114: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 115: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 116: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 117: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 118: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 119: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 120: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 121: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 122: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 123: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 124: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 125: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 126: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 127: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 128: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 129: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 130: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 131: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 132: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 133: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 134: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 135: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 136: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 137: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 138: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 139: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 140: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 141: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 142: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 143: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 144: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 145: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 146: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 147: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 148: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 149: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 150: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 151: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 152: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 153: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 154: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 155: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 156: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 157: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 158: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 159: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 160: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 161: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 162: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 163: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 164: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 165: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 166: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 167: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 168: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 169: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 170: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 171: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 172: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 173: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 174: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 175: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 176: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 177: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 178: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 179: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 180: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 181: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 182: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 183: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 184: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 185: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 186: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 187: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 188: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 189: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 190: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
-- Check 191: Verify the brief distinguishes learning from deciding. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Executive communication should create calibrated belief, not advocacy.
-- Check 192: Verify uncertainty is visible in the main narrative. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Decision quality is different from outcome quality.
-- Check 193: Verify proxy evidence is discounted or caveated. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Reports should separate evidence generation from decision ownership.
-- Check 194: Verify guardrail concerns are not softened away. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Uncertainty, assumptions, external validity, and proxy discounts belong in the main story, not only the appendix.
-- Check 195: Verify decision options and residual risks are explicit. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null results and limitations can be strategically valuable when communicated clearly.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/experiment-decision-review/SKILL.md
+++ b/plugins/experimentation/skills/experiment-decision-review/SKILL.md
@@ -1,300 +1,351 @@
 ---
 name: experiment-decision-review
-description: "Review experiment evidence and recommend ship, kill, iterate, extend, retest, or escalate. Use when results exist and the user needs a decision threshold beyond statistical significance."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Review experiment evidence and recommend ship, kill, iterate, extend, retest, or escalate. Use when results exist and the user needs a decision threshold beyond statistical significance. Proactively suggest this skill when a result is statistically significant but small, flat but potentially useful, early but tempting, or positive with guardrail concerns.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - ship
+  - kill
+  - iterate
+  - extend
+  - retest
+  - decision
+  - results
+  - winner
+  - not significant
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Experiment Decision Review
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an independent experiment adjudicator. Your job is to convert evidence into a defensible decision while preserving uncertainty and separating analysis from executive risk appetite.
 
-## Primary Source Files
+**Hard gate:** Do not recommend shipping until internal validity, practical value, guardrails, and temporal maturity have been checked. If the result is invalid or immature, say so.
 
-- `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`
-- `../../references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`
-- `../../references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md`
-- `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md`
-- `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- A p-value is evidence, not a decision rule by itself.
-- Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Senior decisions need calibrated belief, not false certainty or advocacy.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` | p-values alone are not decision rules. |
+| `../../references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` | Bayesian loss, expected value, case studies, and organizational decision frameworks change stopping criteria. |
+| `../../references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` | early, middle, and late signals answer different questions. |
+| `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` | metrics must map to business strategy and decision value. |
+| `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` | decision communication should build calibrated belief, not certainty theater. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Recover the original hypothesis and pre-registered decision criteria.
-1. Check whether the primary metric matches the stated decision.
-1. Review SRM, exposure integrity, missingness, and instrumentation before outcome interpretation.
-1. Summarize effect size, uncertainty interval, p-value or posterior probability, and practical impact.
-1. Check guardrails before recommending launch.
-1. Evaluate whether the result is mature enough for the claimed outcome.
-1. Distinguish immediate response, validated proxy, and final business outcome.
-1. Assess whether the observed effect clears a minimum meaningful threshold.
-1. Review segment findings for pre-specification and multiple testing risk.
-1. Classify the result as clear win, dangerous win, costly win, flatline, ambiguous signal, or invalid test.
-1. Recommend ship, kill, iterate, extend, retest, or escalate.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- ship
+- kill
+- iterate
+- extend
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `readout-review`: critique a result summary.
+- `decision-memo`: produce a ship/kill/iterate recommendation.
+- `invalidity-triage`: determine whether the result can be trusted.
+- `executive-ready`: prepare leadership-facing recommendation and caveats.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- planned hypothesis and decision rule
+- sample sizes and observed outcomes by variant
+- allocation plan for SRM check
+- duration and time-windowed trend if available
+- guardrail metrics and thresholds
+- implementation notes or known incidents
+- segment analysis plan if segment claims are made
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`, search for decision thresholds, expected loss, OEC, guardrails, and decision latency.
+- In `02g. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`, search for practitioner-facing decision rules and beyond p-values.
+- In `02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`, search for concise stopping guidance.
+- In `15. Experimentation Metrics That Align with Business Strategy.md`, search for asymmetric loss, Value of Information, non-inferiority, trust, and proxy inflation.
+- In `16. Communicating Experiment Results to Senior Stakeholders.md`, search for executive framing, caveats, and recommendation discipline.
+
+### Inspect Locally
+
+- Pre-registration, original metric hierarchy, analysis notebook, dashboard export, and stakeholder decision memo.
+- Assignment, exposure, SRM, ramp, guardrail, and monitoring logs if supplied.
+- Any changes to metric definitions, stop dates, segments, or exclusions after launch.
+
+### Review Protocol
+
+- Reconstruct the original decision before looking at the preferred outcome.
+- Verify execution quality before interpreting effect estimates.
+- Separate statistical uncertainty from business actionability.
+- Check whether the observed interval excludes unacceptable harm, not only whether it excludes zero.
+- Evaluate guardrails before recommending ship.
+- Treat post-hoc segment wins as exploration unless they were pre-registered or externally validated.
+
+### Decision Ledger Schema
+
+For `.experimentation/decision-memos/<experiment_id>.md`, include:
+
+- decision: ship, kill, iterate, extend, escalate, or archive;
+- evidence grade: strong, adequate, weak, invalid, or exploratory;
+- original plan fidelity: matched, minor drift, major drift, or unavailable;
+- primary effect, uncertainty interval, guardrail status, and operational quality;
+- expected upside, expected downside, uncertainty cost, and recommended owner action.
+
+### Red Flags
+
+- The report says "significant" without a business threshold.
+- Guardrail harm is explained away after the primary metric wins.
+- The stopping date moved after data inspection.
+- Segment claims are used to launch broadly.
+- The conclusion would change if stated as expected loss instead of p-value.
+
+## Domain Workflow
+
+1. Recover original hypothesis, primary metric, guardrails, and decision criteria.
+1. Check assignment, exposure, SRM, missingness, data windows, and logging symmetry.
+1. Summarize effect size, interval, p-value or posterior, and practical magnitude.
+1. Compare observed effect to the minimum meaningful effect.
+1. Check secondary metrics and guardrails before decision recommendation.
+1. Assess temporal maturity: early health signal, stable result, delayed outcome, novelty, primacy, or censoring.
+1. Check whether segments were pre-specified and adequately powered.
+1. Classify the result: clear win, dangerous win, costly win, flatline, ambiguous, invalid, or immature.
+1. Apply decision options: ship, kill, iterate, extend, retest, investigate, or escalate.
 1. State what would change the recommendation.
-1. If evidence is weak, recommend the cheapest path to stronger evidence.
-1. If guardrails fail, prioritize mitigation over primary-metric lift.
-1. Document decision rights and residual risk.
+1. Identify the cheapest next evidence if uncertainty is decision-relevant.
+1. Separate evidence recommendation from executive risk appetite.
+1. Prepare a durable memo if the result will guide future teams.
 
-## Questions To Resolve
+## Decision Gates
 
-- Was the decision rule written before data collection?
-- Does the primary result have practical value after implementation cost?
-- Did any guardrail breach the pre-defined threshold?
-- Is the result stable across the relevant maturity window?
-- What action is reversible, and what action creates lock-in?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Is the result internally valid enough to interpret?
+- D2: Does the effect clear practical significance?
+- D3: Do guardrails permit action?
+- D4: Is the result mature enough for the decision?
+- D5: Ship, kill, iterate, extend, retest, or escalate.
 
-- Decision memo
-- Evidence validity assessment
-- Guardrail status
-- Business impact estimate
-- Residual risk and caveats
-- Recommended next action
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `regulated-experiment-auditor` for independent design, implementation, analysis, and decision-quality review.
+- `executive-brief-editor` for calibrated senior stakeholder communication.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- decision memo
+- validity assessment
+- effect and uncertainty summary
+- guardrail status table
+- recommended action and residual risk
+- artifact-ready repository summary
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: experiment-decision-review
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md
+  - 02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md
+  - 24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md
+  - 15. Experimentation Metrics That Align with Business Strategy.md
+  - 16. Communicating Experiment Results to Senior Stakeholders.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The verdict follows from pre-registered criteria or states that criteria were absent.
+- The answer does not let statistical significance override guardrail failure.
+- The answer distinguishes no-effect from no-evidence.
+- The answer identifies stale or immature evidence.
+- The final status is `DONE_WITH_CONCERNS` when residual uncertainty materially affects action.
 
 ## Anti-Patterns To Block
 
-- Declaring a winner only because p is below 0.05.
-- Shipping a costly feature after a statistically significant but trivial effect.
-- Ignoring a guardrail failure because the primary metric improved.
-- Treating exploratory segment wins as confirmed personalization rules.
-- Extending a test only because the current result is inconvenient.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 002: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 003: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 004: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 005: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 006: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 007: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 008: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 009: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 010: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 011: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 012: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 013: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 014: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 015: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 016: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 017: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 018: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 019: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 020: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 021: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 022: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 023: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 024: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 025: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 026: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 027: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 028: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 029: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 030: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 031: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 032: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 033: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 034: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 035: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 036: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 037: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 038: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 039: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 040: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 041: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 042: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 043: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 044: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 045: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 046: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 047: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 048: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 049: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 050: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 051: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 052: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 053: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 054: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 055: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 056: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 057: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 058: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 059: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 060: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 061: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 062: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 063: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 064: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 065: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 066: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 067: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 068: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 069: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 070: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 071: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 072: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 073: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 074: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 075: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 076: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 077: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 078: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 079: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 080: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 081: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 082: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 083: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 084: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 085: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 086: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 087: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 088: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 089: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 090: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 091: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 092: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 093: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 094: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 095: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 096: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 097: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 098: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 099: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 100: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 101: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 102: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 103: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 104: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 105: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 106: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 107: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 108: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 109: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 110: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 111: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 112: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 113: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 114: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 115: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 116: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 117: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 118: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 119: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 120: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 121: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 122: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 123: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 124: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 125: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 126: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 127: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 128: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 129: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 130: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 131: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 132: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 133: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 134: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 135: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 136: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 137: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 138: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 139: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 140: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 141: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 142: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 143: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 144: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 145: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 146: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 147: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 148: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 149: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 150: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 151: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 152: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 153: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 154: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 155: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 156: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 157: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 158: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 159: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 160: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 161: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 162: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 163: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 164: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 165: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 166: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 167: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 168: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 169: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 170: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 171: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 172: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 173: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 174: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 175: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 176: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 177: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 178: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 179: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 180: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 181: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 182: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 183: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 184: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 185: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 186: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 187: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 188: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 189: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 190: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
-- Check 191: Verify the decision criteria existed before results were known. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that A p-value is evidence, not a decision rule by itself.
-- Check 192: Verify the evidence has internal validity before assessing business value. Ground this in `references/notebook/02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Decision quality depends on pre-registered criteria, evidence validity, business value, guardrails, and reversibility.
-- Check 193: Verify practical significance and implementation cost are included. Ground this in `references/notebook/24. Temporal Dynamics of Experiment Data_ Early, Middle, and Late Signals.md` and preserve the claim that Early, middle, and late signals answer different questions and should not be collapsed into one verdict.
-- Check 194: Verify temporal maturity matches the decision being made. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that A flat or null result can be a useful decision signal when the test was adequately powered and well executed.
-- Check 195: Verify the final recommendation names residual uncertainty. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Senior decisions need calibrated belief, not false certainty or advocacy.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/experiment-operating-model/SKILL.md
+++ b/plugins/experimentation/skills/experiment-operating-model/SKILL.md
@@ -1,300 +1,345 @@
 ---
 name: experiment-operating-model
-description: "Design an experimentation operating model, center of excellence, review board, maturity curve, first-year roadmap, governance process, decision rights, and earned autonomy model."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Design an experimentation operating model, center of excellence, review board, maturity curve, first-year roadmap, governance process, decision rights, and earned autonomy model. Proactively suggest this skill when the issue is repeatable experimentation capability rather than one test.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - operating model
+  - center of excellence
+  - CoE
+  - review board
+  - maturity
+  - roadmap
+  - governance
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Experiment Operating Model
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an experimentation operating model advisor. Your job is to design the system that decides what counts as evidence and how teams earn autonomy.
 
-## Primary Source Files
+**Hard gate:** Do not recommend decentralization without standards, repository practices, risk tiers, and independent review paths.
 
-- `../../references/notebook/14. Building an Experimentation Operating Model.md`
-- `../../references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md`
-- `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md`
-- `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md`
-- `../../references/notebook/01. Experimentation in Regulated Finance.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Experimentation maturity is an operating model problem, not just a tooling problem.
-- Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Earned autonomy balances speed with governance.
-- Null and negative results need repository practices so learning compounds.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/14. Building an Experimentation Operating Model.md` | experimentation at scale requires separation of powers, governance bodies, and validity as currency. |
+| `../../references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` | organizations evolve through maturity phases from holdouts to embedded experimentation. |
+| `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` | learning systems must capture null and negative results. |
+| `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` | safe first experiments earn the right to scale. |
+| `../../references/notebook/01. Experimentation in Regulated Finance.md` | regulated experimentation must integrate risk management and independent validation. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Assess current maturity and current pain points.
-1. Identify who proposes, builds, analyzes, approves, and audits experiments.
-1. Define governance bodies such as steering committee, experiment review board, compliance gate, and audit function.
-1. Create risk tiers with approval requirements.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- operating model
+- center of excellence
+- CoE
+- review board
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `maturity-assessment`: diagnose current state.
+- `model-design`: propose governance and roles.
+- `first-year-roadmap`: sequence capability building.
+- `artifact-system`: define repository, templates, and decision records.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- current process and ownership
+- number and type of experiments run
+- approval bottlenecks and risk incidents
+- existing templates and repositories
+- tooling and data maturity
+- regulatory or trust constraints
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `14. Building an Experimentation Operating Model.md`, search for separation of powers, review board, validity as currency, decision rights, and governance.
+- In `21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md`, search for holdouts, executive sponsor, maturity stages, embedded culture, HiPPO, and roadmap.
+- In `03m. The Role of Null Results in Mature Experimentation Programs.md`, search for knowledge base, psychological safety, tags, and reward systems.
+- In `22. Designing “Safe First Experiments” in High-Trust Organizations.md`, search for sequencing, safe first experiments, and earning trust.
+- In `01. Experimentation in Regulated Finance.md`, search for risk management, independent validation, and model risk.
+
+### Inspect Locally
+
+- Existing experiment repository, intake process, review checklist, decision forum, metric standards, and training docs.
+- Ownership model across product, marketing, analytics, engineering, compliance, legal, and risk.
+- Current maturity symptoms: ad hoc holdouts, centralized bottleneck, metric drift, self-review, or low trust.
+
+### Operating Model Protocol
+
+- Diagnose maturity before prescribing structure.
+- Separate experiment builders, evidence reviewers, and decision owners for regulated or high-stakes work.
+- Design earned autonomy: teams gain speed by meeting standards, not by bypassing review.
+- Make null-result capture part of the operating model.
+- Define review tiers by risk, not by political importance.
+- Prefer a thin center of excellence that sets standards and enables teams over a permanent analysis bottleneck.
+
+### Output Schema
+
+For `.experimentation/operating-model.md` or `.experimentation/reviews/<program>.md`, include:
+
+- maturity diagnosis, current failure modes, and target operating state;
+- roles, RACI, risk tiers, review gates, artifact standards, repository fields, and training needs;
+- first-year roadmap with safe-first experiments, enablement milestones, and trust-building proof points;
+- autonomy rules, escalation paths, and health metrics for the experimentation program.
+
+### Red Flags
+
+- A team both builds, analyzes, and approves its own high-risk experiment.
+- The program rewards only wins and hides nulls.
+- Governance is treated as a meeting rather than a decision system.
+- The CoE becomes a queue that slows every test.
+- Maturity roadmap skips from basic holdouts to adaptive personalization without capability gates.
+
+## Domain Workflow
+
+1. Assess maturity: ad hoc, centralized, hybrid, distributed, or embedded.
+1. Map decision rights for product, engineering, data science, compliance, risk, finance, and leadership.
+1. Define steering committee, experiment review board, compliance gate, and audit function.
+1. Define risk tiers and approval requirements.
 1. Define pre-registration, metric taxonomy, guardrail standards, and decision templates.
-1. Define a repository schema for wins, nulls, negatives, invalid tests, and inconclusive tests.
-1. Design a safe-first experiment sequence that earns trust.
-1. Create training and enablement for distributed teams.
-1. Define earned autonomy criteria based on quality, compliance, and execution reliability.
+1. Define repository schema for wins, nulls, negatives, invalid tests, and inconclusive tests.
+1. Create safe-first experiment sequence.
+1. Create training, enablement, and earned autonomy criteria.
 1. Plan migration from centralized support to hybrid governance.
-1. Include Finance in calibration and value realization.
-1. Define global holdout or cumulative impact measurement where feasible.
+1. Include Finance in value realization and calibration.
 1. Identify failure modes and mitigation actions.
-1. Build a first-year roadmap with phases and artifacts.
-1. Specify how the operating model will be measured.
+1. Define operating metrics for the experimentation program itself.
 
-## Questions To Resolve
+## Decision Gates
 
-- What decisions currently rely on opinion instead of evidence?
-- Where does governance slow learning, and where does missing governance create risk?
-- Who can stop an experiment?
-- How are null results preserved and searched?
-- What must a team prove before earning more autonomy?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Centralized, hybrid, or distributed model.
+- D2: Risk tier taxonomy and approval gates.
+- D3: Repository standard and null-result policy.
+- D4: First-year roadmap scope.
 
-- Operating model proposal
-- Governance body charter
-- Risk-tiering framework
-- First-year roadmap
-- Repository and artifact standards
-- Maturity assessment
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+- `operating-model-advisor` for CoE, maturity, review boards, decision rights, training, and earned autonomy.
+- `experiment-librarian` for null results, tagging, repository design, institutional memory, and meta-analysis.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- operating model proposal
+- governance charter
+- risk-tiering framework
+- artifact taxonomy
+- first-year roadmap
+- maturity scorecard
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: experiment-operating-model
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 14. Building an Experimentation Operating Model.md
+  - 21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md
+  - 03m. The Role of Null Results in Mature Experimentation Programs.md
+  - 22. Designing “Safe First Experiments” in High-Trust Organizations.md
+  - 01. Experimentation in Regulated Finance.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The model names roles and decision rights.
+- The roadmap starts with safe trust-building experiments.
+- The repository includes null and negative results.
+- The governance scales by risk tier.
+- The system includes measures of realized value, not just test volume.
 
 ## Anti-Patterns To Block
 
-- Buying an experimentation tool and calling that a program.
-- Letting product teams grade their own tests without challenge.
-- Centralizing so heavily that teams create shadow experimentation.
-- Rewarding only wins and burying null results.
-- Scaling experimentation before metric and compliance standards exist.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 002: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 003: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 004: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 005: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 006: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 007: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 008: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 009: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 010: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 011: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 012: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 013: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 014: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 015: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 016: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 017: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 018: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 019: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 020: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 021: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 022: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 023: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 024: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 025: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 026: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 027: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 028: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 029: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 030: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 031: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 032: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 033: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 034: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 035: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 036: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 037: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 038: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 039: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 040: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 041: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 042: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 043: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 044: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 045: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 046: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 047: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 048: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 049: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 050: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 051: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 052: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 053: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 054: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 055: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 056: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 057: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 058: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 059: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 060: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 061: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 062: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 063: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 064: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 065: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 066: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 067: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 068: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 069: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 070: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 071: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 072: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 073: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 074: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 075: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 076: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 077: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 078: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 079: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 080: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 081: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 082: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 083: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 084: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 085: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 086: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 087: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 088: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 089: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 090: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 091: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 092: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 093: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 094: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 095: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 096: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 097: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 098: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 099: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 100: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 101: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 102: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 103: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 104: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 105: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 106: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 107: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 108: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 109: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 110: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 111: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 112: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 113: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 114: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 115: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 116: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 117: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 118: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 119: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 120: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 121: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 122: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 123: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 124: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 125: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 126: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 127: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 128: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 129: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 130: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 131: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 132: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 133: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 134: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 135: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 136: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 137: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 138: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 139: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 140: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 141: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 142: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 143: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 144: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 145: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 146: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 147: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 148: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 149: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 150: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 151: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 152: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 153: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 154: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 155: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 156: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 157: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 158: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 159: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 160: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 161: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 162: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 163: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 164: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 165: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 166: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 167: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 168: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 169: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 170: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 171: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 172: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 173: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 174: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 175: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 176: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 177: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 178: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 179: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 180: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 181: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 182: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 183: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 184: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 185: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 186: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 187: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 188: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 189: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 190: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
-- Check 191: Verify decision rights are explicit. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Experimentation maturity is an operating model problem, not just a tooling problem.
-- Check 192: Verify independent evidence review exists for material decisions. Ground this in `references/notebook/21m. From Holdouts to Experimentation - The First-Year Maturity Curve.md` and preserve the claim that Conservative organizations need separation among hypothesis owners, implementers, evidence adjudicators, and risk reviewers.
-- Check 193: Verify null results have a repository path. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A center of excellence can incubate standards but can become a bottleneck if distributed capability never matures.
-- Check 194: Verify governance scales by risk tier. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Earned autonomy balances speed with governance.
-- Check 195: Verify the roadmap starts with safe trust-building experiments. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Null and negative results need repository practices so learning compounds.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/measurement-integration/SKILL.md
+++ b/plugins/experimentation/skills/measurement-integration/SKILL.md
@@ -1,300 +1,342 @@
 ---
 name: measurement-integration
-description: "Integrate experiment evidence with MMM, attribution, geo-lift, global holdouts, proxy metrics, incrementality calibration, and marketing measurement governance."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Integrate experiment evidence with MMM, attribution, geo-lift, global holdouts, proxy metrics, incrementality calibration, and marketing measurement governance. Proactively suggest this skill when different measurement systems conflict or when experiment results need to calibrate budget decisions.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - MMM
+  - attribution
+  - MTA
+  - geo-lift
+  - measurement
+  - calibration
+  - budget
+  - ROI
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Measurement Integration
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a marketing measurement architect. Your job is to place experiments inside a hierarchy of evidence so decisions do not confuse attribution, prediction, and causality.
 
-## Primary Source Files
+**Hard gate:** Do not let platform attribution or model precision substitute for causal evidence. If evidence sources conflict, make the conflict explicit.
 
-- `../../references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md`
-- `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md`
-- `../../references/notebook/09. Measuring Incrementality in Email Marketing.md`
-- `../../references/notebook/14. Building an Experimentation Operating Model.md`
-- `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Global holdouts help measure cumulative program impact and the trust gap.
-- Measurement governance should prevent validity laundering through precise but weak dashboards.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` | experiments should be causal anchors in a system of uncertain evidence. |
+| `../../references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` | metrics should map to strategy and decision economics. |
+| `../../references/notebook/09. Measuring Incrementality in Email Marketing.md` | incrementality requires holdouts and causal framing. |
+| `../../references/notebook/14. Building an Experimentation Operating Model.md` | decision rights and governance prevent validity laundering. |
+| `../../references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` | leaders need calibrated uncertainty, not certainty theater. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Identify the budget, channel, product, or strategy decision being informed.
-1. List evidence sources: randomized tests, holdouts, geo-lift, MMM, attribution, platform reports, and actuals.
-1. Classify each source by causal strength, granularity, latency, bias, and decision relevance.
-1. Use experiments to calibrate priors, validate MMM, or challenge attribution claims.
-1. Identify conflicts among evidence sources and explain plausible causes.
-1. Check whether proxy metrics require discounts before financial forecasting.
-1. Recommend global holdouts when individual experiment wins do not reconcile to business growth.
-1. Assess whether geo-lift is more appropriate than user-level testing.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- MMM
+- attribution
+- MTA
+- geo-lift
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `evidence-hierarchy`: rank sources by causal strength and decision fit.
+- `model-conflict`: reconcile experiment, MMM, attribution, and actuals.
+- `calibration-plan`: use experiments or holdouts to calibrate models.
+- `budget-decision`: translate evidence into allocation implications.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- experiment or holdout lift estimates
+- MMM or attribution outputs
+- business actuals or finance targets
+- channel spend and timing
+- proxy metric relationships
+- decision owner and budget constraints
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md`, search for causal anchor, attribution/MTA, calibrated MMM, dashboard mirage, validity laundering, and measurement hierarchy.
+- In `15. Experimentation Metrics That Align with Business Strategy.md`, search for proxy inflation, OEC pyramid, asymmetric loss, surrogate index, and trust as an asset.
+- In `20. The Future of Experimentation in Marketing (2025–2030).md`, search for privacy, AI, synthetic controls, continuous measurement, and future measurement constraints.
+- In `Slide Deck 6 - Where Experiments Fit in Marketing Measurement.md`, search for practical slide-level framing of experiments, MMM, and attribution.
+- In `09. Measuring Incrementality in Email Marketing.md`, search for holdouts and causal calibration in email.
+
+### Inspect Locally
+
+- MMM outputs, attribution dashboards, incrementality tests, geo-lift studies, holdouts, campaign taxonomy, and metric dictionaries.
+- Whether models use experiment results as calibration anchors or merely as narrative support.
+- The business question: allocation, creative decision, channel budget, targeting, or executive confidence.
+
+### Integration Protocol
+
+- Establish which method is the causal anchor and which methods are allocators, generalizers, or diagnostics.
+- Treat attribution as granular allocation support, not causal proof.
+- Use experiments to calibrate MMM when randomization scope and external validity are clear.
+- Translate disagreement among methods into a decision memo, not a blended false certainty.
+- Require a measurement hierarchy before building dashboards.
+- Identify where privacy, lag, noise, and beta make randomized evidence scarce or expensive.
+
+### Output Schema
+
+For `.experimentation/measurement/<topic>.md`, include:
+
+- decision question, methods compared, evidence tier, causal claim supported, and unsupported claims;
+- experiment-to-MMM calibration plan, attribution usage boundary, holdout strategy, and refresh cadence;
+- disagreement table: method, estimate, assumptions, bias risk, decision role, and owner;
+- recommendation for budget, channel, creative, targeting, or additional evidence.
+
+### Red Flags
+
+- A dashboard averages experiments, MMM, and attribution into one certainty score.
+- Attribution is used to claim incremental lift.
+- Experiment results are generalized to channels or populations never randomized.
+- MMM ignores randomized calibration evidence.
+- Stakeholders ask "which number is right" when the real issue is different estimands.
+
+## Domain Workflow
+
+1. Identify the decision: budget, channel strategy, product, customer segment, or reporting claim.
+1. Inventory evidence sources: experiment, holdout, geo-lift, MMM, attribution, platform report, and financial actuals.
+1. Rank sources by causal strength, granularity, latency, bias, and scope.
+1. Use experiments to calibrate priors, validate MMM, or challenge attribution.
+1. Identify conflicts and likely causes: selection bias, prior-data conflict, seasonality, lag, incrementality gap, or proxy failure.
+1. Apply proxy discounts before financial forecasting.
+1. Recommend global holdout when individual wins do not reconcile to business actuals.
+1. Recommend geo-lift when user-level randomization is infeasible.
 1. Define decision rights when models disagree.
-1. Translate evidence into budget or strategy implications.
-1. Flag where uncertainty is being hidden by dashboards.
-1. Suggest governance artifacts such as evidence cards, calibration logs, and decision memos.
-1. Separate allocation optimization from causal learning.
-1. Protect against overclaiming platform-reported ROI.
-1. Document what future experiment would reduce the largest uncertainty.
+1. Produce a calibration or measurement governance artifact.
 
-## Questions To Resolve
+## Decision Gates
 
-- Which decision will change if this evidence is accepted?
-- Which evidence source is most causal and which is most scalable?
-- Do experiment results reconcile with financial actuals?
-- Is MMM being calibrated by lift studies or treated as standalone truth?
-- Where could attribution be laundering selection bias into precision?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Which evidence source is causal enough for the decision?
+- D2: Does experiment evidence calibrate or override model output?
+- D3: Is a global holdout or geo-lift needed?
+- D4: What claim can be made to leadership?
 
-- Evidence hierarchy
-- Measurement conflict analysis
-- Calibration plan
-- Global holdout or geo-lift recommendation
-- Decision-rights memo
-- Budget implication summary
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+- `executive-brief-editor` for calibrated senior stakeholder communication.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- measurement evidence hierarchy
+- model conflict memo
+- calibration plan
+- global holdout or geo-lift proposal
+- budget implication summary
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: measurement-integration
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md
+  - 15. Experimentation Metrics That Align with Business Strategy.md
+  - 09. Measuring Incrementality in Email Marketing.md
+  - 14. Building an Experimentation Operating Model.md
+  - 16. Communicating Experiment Results to Senior Stakeholders.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The answer distinguishes causal lift from attributed credit.
+- The answer names conflicts rather than smoothing them away.
+- The answer links measurement to a concrete decision.
+- The answer prevents proxy lift from becoming revenue certainty.
+- The answer recommends governance when evidence sources disagree.
 
 ## Anti-Patterns To Block
 
-- Treating attribution credit as incrementality.
-- Ignoring experiments because they are smaller than MMM scope.
-- Using MMM without calibration or prior-data conflict checks.
-- Summing individual test lifts into an unrealistic forecast.
-- Reporting proxy lift as revenue lift without discounting.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 002: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 003: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 004: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 005: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 006: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 007: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 008: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 009: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 010: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 011: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 012: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 013: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 014: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 015: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 016: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 017: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 018: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 019: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 020: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 021: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 022: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 023: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 024: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 025: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 026: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 027: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 028: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 029: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 030: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 031: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 032: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 033: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 034: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 035: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 036: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 037: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 038: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 039: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 040: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 041: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 042: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 043: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 044: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 045: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 046: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 047: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 048: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 049: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 050: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 051: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 052: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 053: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 054: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 055: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 056: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 057: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 058: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 059: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 060: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 061: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 062: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 063: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 064: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 065: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 066: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 067: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 068: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 069: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 070: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 071: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 072: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 073: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 074: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 075: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 076: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 077: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 078: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 079: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 080: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 081: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 082: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 083: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 084: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 085: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 086: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 087: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 088: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 089: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 090: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 091: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 092: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 093: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 094: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 095: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 096: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 097: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 098: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 099: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 100: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 101: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 102: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 103: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 104: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 105: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 106: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 107: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 108: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 109: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 110: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 111: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 112: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 113: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 114: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 115: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 116: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 117: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 118: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 119: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 120: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 121: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 122: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 123: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 124: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 125: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 126: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 127: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 128: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 129: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 130: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 131: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 132: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 133: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 134: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 135: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 136: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 137: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 138: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 139: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 140: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 141: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 142: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 143: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 144: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 145: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 146: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 147: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 148: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 149: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 150: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 151: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 152: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 153: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 154: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 155: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 156: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 157: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 158: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 159: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 160: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 161: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 162: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 163: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 164: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 165: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 166: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 167: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 168: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 169: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 170: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 171: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 172: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 173: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 174: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 175: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 176: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 177: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 178: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 179: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 180: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 181: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 182: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 183: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 184: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 185: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 186: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 187: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 188: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 189: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 190: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
-- Check 191: Verify causal strength is ranked explicitly. Ground this in `references/notebook/19. Unified Measurement_ How Experiments Fit with MMM and Attribution.md` and preserve the claim that Experiments should act as causal anchors in a broader system of uncertain evidence.
-- Check 192: Verify experiments calibrate broader models where possible. Ground this in `references/notebook/15. Experimentation Metrics That Align with Business Strategy.md` and preserve the claim that Attribution and MTA can allocate credit but often have weaker causal validity than randomized evidence.
-- Check 193: Verify cumulative impact is checked through holdouts or actuals. Ground this in `references/notebook/09. Measuring Incrementality in Email Marketing.md` and preserve the claim that MMM can generalize at broader levels but should be calibrated against experimental lift where possible.
-- Check 194: Verify proxy metrics are discounted before forecasting. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Global holdouts help measure cumulative program impact and the trust gap.
-- Check 195: Verify decision rights are defined when evidence conflicts. Ground this in `references/notebook/16. Communicating Experiment Results to Senior Stakeholders.md` and preserve the claim that Measurement governance should prevent validity laundering through precise but weak dashboards.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/null-results-knowledge-base/SKILL.md
+++ b/plugins/experimentation/skills/null-results-knowledge-base/SKILL.md
@@ -1,300 +1,344 @@
 ---
 name: null-results-knowledge-base
-description: "Capture null, flat, negative, and inconclusive experiment results into a reusable knowledge base. Use for experiment repository schemas, learning summaries, tagging, meta-analysis, repeated-test prevention, and institutional memory."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Capture null, flat, negative, and inconclusive experiment results into a reusable knowledge base. Use for experiment repository schemas, learning summaries, tagging, meta-analysis, repeated-test prevention, and institutional memory. Proactively suggest this skill after flat, invalid, negative, or ambiguous tests.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - null result
+  - flat
+  - negative
+  - inconclusive
+  - repository
+  - knowledge base
+  - learning
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Null Results Knowledge Base
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are an experimentation knowledge librarian. Your job is to make null and negative results compound into institutional memory instead of disappearing.
 
-## Primary Source Files
+**Hard gate:** Do not classify a non-significant result as no-effect until power, execution quality, metric validity, and heterogeneity have been checked.
 
-- `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md`
-- `../../references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md`
-- `../../references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md`
-- `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md`
-- `../../references/notebook/14. Building an Experimentation Operating Model.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Null and negative results are valuable institutional assets when properly classified and searchable.
-- A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Learning cultures reward evidence quality and insight, not only winning treatments.
-- Meta-analysis across stored experiments can reveal patterns no single experiment can show.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` | null and negative results are an unseen engine of learning when recorded well. |
+| `../../references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` | mature programs normalize and reuse failed hypotheses. |
+| `../../references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` | compact null-result guidance emphasizes learning value. |
+| `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` | flat averages can hide heterogeneous response. |
+| `../../references/notebook/14. Building an Experimentation Operating Model.md` | institutional memory and repository standards are operating-model requirements. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Recover the original hypothesis, decision metric, sample size, duration, and guardrails.
-1. Classify the result as win, true null, underpowered null, negative, invalid, inconclusive, or heterogeneous offset.
-1. Assess whether execution quality supports learning from the result.
-1. Document metric validity and whether the test measured the intended mechanism.
-1. Record segment observations as exploratory unless pre-specified and powered.
-1. Extract the reusable lesson in one sentence.
-1. Tag product, channel, audience, journey stage, hypothesis type, metric, mechanism, and risk tier.
-1. Link source data, analysis, design brief, decision memo, and variant artifacts where available.
-1. State whether a similar test should be avoided, repeated with changes, or escalated to a different method.
-1. Identify follow-up hypotheses created by the result.
-1. Record what not to conclude from the evidence.
-1. Add compliance or trust lessons if relevant.
-1. Make the record searchable by future teams.
-1. When multiple records exist, synthesize patterns and contradictions.
-1. Use the repository to update priors, standards, and roadmaps.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- null result
+- flat
+- negative
+- inconclusive
 
-## Questions To Resolve
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
 
-- Was this result informative or invalid?
-- What did the organization learn that should persist?
-- What future test would be wasteful because of this evidence?
-- Was the flat result caused by average cancellation across segments?
-- Which tags will help another team find this result later?
 
-## Expected Outputs
+## Advanced Operating Loop
 
-- Repository-ready experiment record
-- Null-result classification
-- Reusable lesson
-- Metadata and tags
-- Retest or archive recommendation
-- Meta-analysis cues
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `single-record`: create a repository-ready record for one result.
+- `classification`: decide whether a result is true null, underpowered, invalid, negative, or heterogeneous.
+- `schema-design`: design repository fields and tags.
+- `meta-analysis`: synthesize patterns across stored results.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- original design and hypothesis
+- result and power context
+- execution quality diagnostics
+- metric definitions and guardrails
+- segment analysis and whether it was pre-specified
+- decision memo and final action
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `03m. The Role of Null Results in Mature Experimentation Programs.md`, search for knowledge base, hypothesis, tags, segmentation, psychological safety, and repeated failed experiments.
+- In `03g. The Role of Null Results in Mature Experimentation Programs.md`, search for mature program practices and reuse of failed hypotheses.
+- In `03c. The Role of Null Results in Mature Experimentation Programs.md`, search for compact guidance on documenting and sharing negative results.
+- In `11. From ATE to CATE_ Extracting Value from Flat Experiments.md`, search for offsetting effects, flat averages, CATE, and segment-level learning.
+- In `14. Building an Experimentation Operating Model.md`, search for repository standards and institutional memory.
+
+### Inspect Locally
+
+- Existing experiment repository, prior learning logs, tags, report templates, and repeated experiments.
+- The original hypothesis, design quality, power/MDE, metric validity, guardrails, and segment plan.
+- Whether the result is truly null, negative, inconclusive, invalid, underpowered, or mixed.
+
+### Knowledge Capture Protocol
+
+- Do not collapse all non-wins into "no effect."
+- Classify why the result was non-winning: flawed hypothesis, weak treatment, insufficient power, invalid execution, offsetting segments, bad metric, or genuine no meaningful effect.
+- Preserve what was learned, what should not be repeated, and what remains worth testing.
+- Add tags that a future team would actually search.
+- Include enough context to prevent wrong generalization.
+- Normalize nulls as evidence, not failure.
+
+### Repository Schema
+
+For `.experimentation/repository/learnings.jsonl`, use one object per line with:
+
+- `experiment_id`, `date`, `result_type`, `hypothesis`, `surface`, `population`, `treatment`, `primary_metric`, `effect_summary`;
+- `quality_grade`, `power_assessment`, `validity_notes`, `segment_notes`, `guardrail_notes`;
+- `learning`, `do_not_repeat`, `promising_followups`, `tags`, `sources`, `confidence`, and `owner`.
+
+For Markdown summaries, include hypothesis, design, results, interpretation, tags, and next actions.
+
+### Red Flags
+
+- The team treats non-significance as proof of no effect.
+- A flat ATE hides meaningful segment harm or benefit.
+- The result is underpowered but archived as a strategic learning.
+- The same failed idea has no searchable tag history.
+- Null documentation blames the team instead of updating the mental model.
+
+## Domain Workflow
+
+1. Recover hypothesis, decision metric, sample size, duration, guardrails, and result.
+1. Assess execution quality and whether the result can teach anything.
+1. Classify result: win, true null, underpowered null, negative, invalid, inconclusive, or heterogeneous offset.
+1. Document metric validity and mechanism tested.
+1. Label segment observations as exploratory unless pre-specified and powered.
+1. Extract one durable lesson and one thing not to conclude.
+1. Tag product, channel, audience, journey stage, hypothesis type, mechanism, metric, risk tier, and time period.
+1. Link design brief, analysis, decision memo, variants, and source data where available.
+1. Recommend avoid, repeat with changes, test stronger contrast, inspect CATE, validate proxy, or archive.
+1. Append to JSONL if writing artifacts is in scope.
+1. Update standards or priors when repeated patterns emerge.
+
+## Decision Gates
+
+Use these decision gates when the task crosses a material choice:
+
+- D1: Informative result vs invalid result.
+- D2: True null vs underpowered no-evidence.
+- D3: Archive, retest, redesign, or synthesize.
+- D4: Write durable repository artifact now or provide artifact-ready block.
+
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `regulated-experiment-auditor` for independent design, implementation, analysis, and decision-quality review.
+- `experiment-librarian` for null results, tagging, repository design, institutional memory, and meta-analysis.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- repository-ready experiment record
+- classification and confidence
+- metadata tags
+- reusable lesson
+- what-not-to-conclude note
+- retest or archive recommendation
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: null-results-knowledge-base
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 03m. The Role of Null Results in Mature Experimentation Programs.md
+  - 03g. The Role of Null Results in Mature Experimentation Programs.md
+  - 03c. The Role of Null Results in Mature Experimentation Programs.md
+  - 11. From ATE to CATE_ Extracting Value from Flat Experiments.md
+  - 14. Building an Experimentation Operating Model.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The classification distinguishes no-effect from no-evidence.
+- The record is searchable by future teams.
+- The lesson is reusable and not overgeneralized.
+- Exploratory segment findings are labeled correctly.
+- The artifact has enough metadata for meta-analysis.
 
 ## Anti-Patterns To Block
 
-- Calling every non-significant result a failed experiment.
-- Burying negative results because they are politically inconvenient.
-- Recording only wins in the knowledge base.
-- Repeating old tests because prior evidence was not searchable.
-- Treating underpowered nulls as proof of no effect.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 002: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 003: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 004: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 005: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 006: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 007: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 008: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 009: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 010: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 011: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 012: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 013: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 014: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 015: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 016: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 017: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 018: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 019: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 020: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 021: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 022: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 023: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 024: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 025: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 026: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 027: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 028: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 029: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 030: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 031: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 032: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 033: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 034: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 035: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 036: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 037: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 038: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 039: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 040: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 041: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 042: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 043: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 044: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 045: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 046: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 047: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 048: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 049: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 050: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 051: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 052: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 053: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 054: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 055: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 056: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 057: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 058: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 059: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 060: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 061: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 062: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 063: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 064: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 065: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 066: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 067: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 068: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 069: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 070: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 071: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 072: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 073: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 074: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 075: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 076: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 077: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 078: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 079: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 080: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 081: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 082: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 083: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 084: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 085: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 086: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 087: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 088: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 089: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 090: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 091: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 092: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 093: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 094: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 095: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 096: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 097: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 098: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 099: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 100: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 101: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 102: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 103: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 104: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 105: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 106: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 107: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 108: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 109: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 110: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 111: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 112: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 113: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 114: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 115: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 116: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 117: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 118: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 119: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 120: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 121: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 122: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 123: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 124: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 125: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 126: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 127: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 128: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 129: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 130: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 131: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 132: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 133: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 134: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 135: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 136: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 137: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 138: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 139: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 140: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 141: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 142: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 143: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 144: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 145: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 146: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 147: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 148: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 149: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 150: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 151: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 152: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 153: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 154: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 155: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 156: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 157: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 158: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 159: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 160: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 161: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 162: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 163: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 164: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 165: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 166: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 167: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 168: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 169: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 170: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 171: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 172: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 173: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 174: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 175: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 176: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 177: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 178: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 179: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 180: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 181: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 182: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 183: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 184: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 185: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 186: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 187: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 188: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 189: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 190: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
-- Check 191: Verify the result classification distinguishes no-effect from no-evidence. Ground this in `references/notebook/03m. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Null and negative results are valuable institutional assets when properly classified and searchable.
-- Check 192: Verify execution quality supports the claimed lesson. Ground this in `references/notebook/03g. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that A flat result can mean true no-effect, insufficient power, poor implementation, metric mismatch, or offsetting segment effects.
-- Check 193: Verify metadata is sufficient for future discovery. Ground this in `references/notebook/03c. The Role of Null Results in Mature Experimentation Programs.md` and preserve the claim that Repository design should prevent repeated testing of already disproven or low-value hypotheses.
-- Check 194: Verify exploratory segment notes are labeled correctly. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Learning cultures reward evidence quality and insight, not only winning treatments.
-- Check 195: Verify the repository record says what not to conclude. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Meta-analysis across stored experiments can reveal patterns no single experiment can show.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/personalization-governance/SKILL.md
+++ b/plugins/experimentation/skills/personalization-governance/SKILL.md
@@ -1,300 +1,341 @@
 ---
 name: personalization-governance
-description: "Decide whether personalization, segmentation, CATE, uplift modeling, or heterogeneous treatment evidence is strong and safe enough to deploy in high-trust or regulated environments."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Decide whether personalization, segmentation, CATE, uplift modeling, or heterogeneous treatment evidence is strong and safe enough to deploy in high-trust or regulated environments. Proactively suggest this skill when a team wants to target, suppress, personalize, or automate based on subgroup experiment results.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - personalization
+  - CATE
+  - uplift
+  - heterogeneous
+  - segment
+  - targeting
+  - suppression
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Personalization Governance
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a personalization governance reviewer. Your job is to keep teams from turning fragile heterogeneity into expensive, unfair, or unstable targeting logic.
 
-## Primary Source Files
+**Hard gate:** Do not recommend personalization from post-hoc or underpowered segment results. Require validation, fairness review, operational monitoring, and a simpler alternative comparison.
 
-- `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md`
-- `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md`
-- `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md`
-- `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md`
-- `../../references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Post-hoc segment wins require validation before deployment.
-- In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` | flat average effects can hide offsetting treatment effects. |
+| `../../references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` | personalization requires evidence thresholds, reversibility checks, and governance. |
+| `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` | personalization can blur advice boundaries and create disparate impact. |
+| `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md` | targeting can feel manipulative and damage trust. |
+| `../../references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` | adaptive allocation and personalization trade optimization against clean inference and governance. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Identify the proposed personalized action and who receives different treatment.
-1. Clarify whether heterogeneity was pre-specified, exploratory, or model-discovered.
-1. Check sample size and uncertainty within each proposed segment.
-1. Check multiple testing, winner's curse, shrinkage, and out-of-sample validation.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- personalization
+- CATE
+- uplift
+- heterogeneous
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `heterogeneity-review`: inspect subgroup or CATE evidence.
+- `deployment-gate`: decide whether to personalize.
+- `suppression-policy`: decide whether not treating some users is safer.
+- `model-risk-review`: evaluate operational, fairness, and drift controls.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- segment definitions and whether they were pre-specified
+- effect estimates and intervals by segment
+- validation or holdout performance
+- targeting variables and protected-class proxy risk
+- operational implementation plan
+- monitoring and rollback plan
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `12. When (and When Not) to Personalize Based on Experimental Results.md`, search for personalization thresholds, evidence sufficiency, governance, and fairness.
+- In `11. From ATE to CATE_ Extracting Value from Flat Experiments.md`, search for CATE, uplift, Transylvania matrix, cost-sensitive learning, algorithmic redlining, and champion/challenger governance.
+- In `13. Multi-Armed Bandits vs Controlled Experiments.md`, search for adaptive allocation, regret, exploration, and inference tradeoffs.
+- In `17. Experimentation, Trust, and Consumer Perception.md`, search for perceived manipulation, fairness, disclosure, and trust erosion.
+- In `18. Legal and Compliance Considerations in Marketing Experiments.md`, search for protected classes, advice boundaries, privacy, consent, and recordkeeping.
+
+### Inspect Locally
+
+- Segment definitions, model features, treatment assignment logic, decision rules, fairness review notes, and consent/privacy constraints.
+- Evidence that heterogeneity was pre-specified or validated out of sample.
+- Existing champion/challenger, model risk, drift, and monitoring standards.
+
+### Governance Protocol
+
+- Do not personalize from a flat or noisy ATE without validated heterogeneity.
+- Distinguish response heterogeneity from targeting convenience.
+- Require benefit, harm, and fairness checks by segment before deployment.
+- Prefer interpretable segment rules when evidence is early or stakes are high.
+- Use adaptive allocation only when optimization is more important than clean inference, or when a separate holdout preserves learning.
+- Define sunset criteria, drift monitoring, and appeal/escalation path for regulated contexts.
+
+### Output Schema
+
+For `.experimentation/decision-memos/<experiment_id>.md`, include:
+
+- personalization hypothesis, CATE/uplift evidence, validation source, segment definitions, and treatment policy;
+- benefit/harm matrix, protected-class proxy review, disclosure/consent considerations, and operational constraints;
+- holdout or champion/challenger plan, drift thresholds, sunset criteria, and audit fields;
+- decision: do not personalize, limited rules, validated model, bandit, or further experiment.
+
+### Red Flags
+
+- A segment is selected because it is profitable but may be vulnerable or protected.
+- Uplift is inferred from post-hoc slices with no validation.
+- Bandits remove the ability to answer the causal question stakeholders need.
+- Personalization changes advice quality, eligibility, or perceived fairness.
+- No owner is named for model drift, complaint review, or sunset.
+
+## Domain Workflow
+
+1. Identify the personalized action and who receives different treatment.
+1. Classify heterogeneity evidence as pre-specified, exploratory, model-discovered, or externally validated.
+1. Check sample size, uncertainty, multiple comparisons, and winner's curse by segment.
+1. Check out-of-sample validation, holdout confirmation, shrinkage, and stability over time.
 1. Distinguish moderation from mediation.
-1. Assess whether a simple rule performs nearly as well as a complex model.
-1. Evaluate operational complexity and personalization debt.
-1. Check for feedback loops and baseline pollution.
-1. Review disparate impact, proxy discrimination, vulnerability, suitability, and adverse-action concerns.
-1. Assess explainability needs for the domain.
-1. Define monitoring, sunset criteria, and drift checks.
-1. Decide personalize, suppress, use best-for-most, retest, or keep exploratory.
-1. Require compliance review for regulated targeting.
-1. Document which groups could be harmed by the action.
-1. Prefer restraint when evidence strength is lower than deployment risk.
+1. Compare personalization with best-for-most and simple rules.
+1. Assess operational debt, feedback loops, baseline pollution, and drift risk.
+1. Review disparate impact, proxy discrimination, vulnerability, suitability, and adverse-action exposure.
+1. Define monitoring, sunset criteria, and rollback.
+1. Recommend personalize, suppress, best-for-most, retest, or keep exploratory.
 
-## Questions To Resolve
+## Decision Gates
 
-- Was the subgroup hypothesis pre-registered?
-- Does the subgroup effect replicate out of sample?
-- Could the targeting variable proxy for a protected class?
-- What operational debt does personalization create?
-- Would a simpler best-for-most intervention produce safer value?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Is heterogeneity evidence confirmatory enough?
+- D2: Does personalization beat a simpler alternative?
+- D3: Is fairness/model-risk review required before deployment?
+- D4: Personalize, suppress, best-for-most, retest, or archive.
 
-- Personalization decision brief
-- Heterogeneity evidence assessment
-- Fairness and compliance review needs
-- Operational debt assessment
-- Monitoring and sunset plan
-- Recommendation
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `measurement-architect` for MMM, attribution, global holdouts, geo-lift, proxy calibration, and evidence hierarchy.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- personalization evidence review
+- fairness and model-risk checklist
+- deployment decision brief
+- monitoring and sunset plan
+- simpler-alternative comparison
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: personalization-governance
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 11. From ATE to CATE_ Extracting Value from Flat Experiments.md
+  - 12. When (and When Not) to Personalize Based on Experimental Results.md
+  - 18. Legal and Compliance Considerations in Marketing Experiments.md
+  - 17. Experimentation, Trust, and Consumer Perception.md
+  - 13. Multi-Armed Bandits vs Controlled Experiments.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The answer rejects noisy post-hoc targeting.
+- The answer compares against simpler alternatives.
+- The answer names fairness and trust exposure.
+- The answer includes monitoring and sunset criteria.
+- The answer preserves exploratory findings as exploratory.
 
 ## Anti-Patterns To Block
 
-- Deploying personalization from noisy exploratory segments.
-- Ignoring protected-class proxies because protected-class fields are absent.
-- Using uplift models without holdout validation.
-- Creating permanent targeting logic from one temporary experiment.
-- Assuming personalization is always superior to a robust common experience.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 002: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 003: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 004: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 005: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 006: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 007: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 008: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 009: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 010: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 011: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 012: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 013: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 014: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 015: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 016: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 017: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 018: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 019: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 020: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 021: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 022: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 023: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 024: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 025: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 026: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 027: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 028: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 029: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 030: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 031: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 032: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 033: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 034: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 035: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 036: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 037: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 038: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 039: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 040: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 041: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 042: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 043: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 044: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 045: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 046: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 047: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 048: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 049: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 050: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 051: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 052: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 053: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 054: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 055: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 056: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 057: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 058: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 059: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 060: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 061: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 062: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 063: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 064: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 065: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 066: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 067: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 068: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 069: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 070: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 071: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 072: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 073: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 074: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 075: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 076: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 077: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 078: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 079: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 080: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 081: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 082: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 083: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 084: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 085: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 086: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 087: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 088: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 089: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 090: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 091: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 092: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 093: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 094: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 095: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 096: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 097: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 098: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 099: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 100: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 101: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 102: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 103: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 104: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 105: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 106: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 107: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 108: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 109: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 110: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 111: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 112: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 113: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 114: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 115: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 116: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 117: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 118: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 119: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 120: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 121: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 122: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 123: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 124: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 125: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 126: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 127: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 128: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 129: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 130: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 131: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 132: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 133: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 134: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 135: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 136: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 137: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 138: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 139: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 140: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 141: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 142: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 143: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 144: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 145: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 146: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 147: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 148: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 149: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 150: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 151: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 152: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 153: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 154: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 155: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 156: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 157: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 158: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 159: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 160: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 161: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 162: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 163: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 164: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 165: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 166: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 167: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 168: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 169: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 170: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 171: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 172: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 173: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 174: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 175: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 176: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 177: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 178: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 179: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 180: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 181: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 182: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 183: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 184: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 185: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 186: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 187: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 188: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 189: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 190: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
-- Check 191: Verify heterogeneity evidence is not only post-hoc pattern finding. Ground this in `references/notebook/11. From ATE to CATE_ Extracting Value from Flat Experiments.md` and preserve the claim that Flat average effects can hide meaningful heterogeneous effects, but heterogeneity claims are fragile.
-- Check 192: Verify deployment risk is proportionate to validation strength. Ground this in `references/notebook/12. When (and When Not) to Personalize Based on Experimental Results.md` and preserve the claim that Personalization creates operational debt, feedback loops, fairness exposure, and model-risk obligations.
-- Check 193: Verify fairness, vulnerability, and suitability risks are reviewed. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Post-hoc segment wins require validation before deployment.
-- Check 194: Verify model drift and feedback loops have monitoring plans. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that In high-trust settings, best-for-most may be preferable to complex targeting when evidence is weak.
-- Check 195: Verify simpler alternatives were considered. Ground this in `references/notebook/13. Multi-Armed Bandits vs Controlled Experiments.md` and preserve the claim that Suppression and restraint can be valid uplift actions, especially when treatment causes harm for some groups.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/power-duration-planning/SKILL.md
+++ b/plugins/experimentation/skills/power-duration-planning/SKILL.md
@@ -1,300 +1,350 @@
 ---
 name: power-duration-planning
-description: "Plan experiment sample size, power, MDE, duration, traffic feasibility, and low-velocity alternatives. Use when asked how long to run a test, whether a test is feasible, or whether a default 30-day duration is justified."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Plan experiment sample size, power, MDE, duration, traffic feasibility, and low-velocity alternatives. Use when asked how long to run a test, whether a test is feasible, what MDE is realistic, or whether a default 30-day duration is justified. Proactively suggest this skill when traffic is scarce, outcomes are delayed, or stakeholders want to stop early.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - sample size
+  - power
+  - MDE
+  - duration
+  - 30-day
+  - how long
+  - low traffic
+  - early stopping
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Power Duration Planning
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a senior experimentation statistician focused on feasibility and decision latency. Your job is to make duration a defensible risk tradeoff rather than a calendar habit.
 
-## Primary Source Files
+**Hard gate:** Do not bless a duration without baseline, MDE, eligible traffic, metric maturity, and stopping-rule assumptions. If those are missing, provide ranges and mark `NEEDS_CONTEXT`.
 
-- `../../references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md`
-- `../../references/notebook/25m. Debunking the 30-Day-Experiment Myth.md`
-- `../../references/notebook/25c. Debunking the 30-Day-Experiment Myth.md`
-- `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`
-- `../../references/notebook/05. Sequential Testing Methods in Business Experiments.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` | low-volume financial services channels force tradeoffs among confidence, sensitivity, and velocity. |
+| `../../references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` | 30-day duration is often organizational habit rather than evidence-based design. |
+| `../../references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` | duration depends on signal velocity, risk, estimand, temporal dynamics, and organizational implementation. |
+| `../../references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` | stopping requires decision thresholds beyond p-values. |
+| `../../references/notebook/05. Sequential Testing Methods in Business Experiments.md` | sequential methods can shorten decisions only when stopping rules are valid. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Collect baseline rate or mean and variance.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- sample size
+- power
+- MDE
+- duration
+
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
+
+
+## Advanced Operating Loop
+
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `sizing`: calculate or frame sample size and MDE.
+- `duration-review`: critique a proposed run length.
+- `low-velocity-strategy`: recommend alternatives when fixed-horizon testing is infeasible.
+- `stopping-plan`: define fixed, group-sequential, Bayesian, or always-valid monitoring.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- baseline metric and variance or rate
+- MDE and why it is decision-worthy
+- daily eligible randomized units
+- allocation ratio and variant count
+- desired alpha, power, and sidedness
+- metric latency and maturity window
+- seasonality or business-cycle constraints
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md`, search for low-velocity channels, MDE, sensitivity, proxy metrics, and feasibility.
+- In `25m. Debunking the 30-Day-Experiment Myth.md`, search for arbitrary duration, signal velocity, temporal dynamics, and organizational habit.
+- In `25c. Debunking the 30-Day-Experiment Myth.md`, search for duration drivers and decision readiness.
+- In `02m. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md`, search for MDE as a business lever, risk-adjusted thresholds, OEC, and guardrails.
+- In `05. Sequential Testing Methods in Business Experiments.md`, search for peeking, group sequential, alpha spending, always-valid inference, and monitoring cadence.
+
+### Inspect Locally
+
+- Baseline metric history, traffic forecasts, and audience eligibility counts.
+- Prior experiment durations and actual maturation curves.
+- Metric latency, censoring, and delayed-conversion behavior.
+- Existing sequential-testing or Bayesian tooling before recommending custom monitoring.
+
+### Calculation Protocol
+
+- Separate minimum meaningful effect from minimum detectable effect.
+- Use eligible randomized units, not total audience, as the denominator for duration.
+- State assumptions for alpha, power, sidedness, allocation ratio, variant count, variance/rate, metric maturity, and attrition.
+- Produce a sensitivity table across plausible MDEs instead of a single brittle duration.
+- If inputs are missing, provide a feasibility envelope and identify the one input that most changes the answer.
+- Treat 30 days as a hypothesis to justify, not a default.
+
+### Output Schema
+
+For `.experimentation/decision-memos/<experiment_id>.md`, include:
+
+- baseline, variance/rate, MDE, alpha, power, sidedness, allocation, variants, traffic, and maturity window;
+- fixed-horizon estimate, sequential alternative, proxy alternative, and non-experimental alternative;
+- sensitivity table, decision latency cost, opportunity cost, and risk of wrong action;
+- stop/extend/kill rules and any invalid-peeking warning.
+
+### Red Flags
+
+- Stakeholders ask for a launch date before choosing an MDE.
+- The metric cannot mature inside the proposed window.
+- The detectable effect is larger than the effect stakeholders would actually act on.
+- The test has multiple variants but no multiplicity plan.
+- Early stopping is requested without a valid sequential or Bayesian rule.
+
+## Domain Workflow
+
+1. Collect baseline rate or baseline mean and variance.
 1. Collect minimum meaningful effect in absolute and relative terms.
-1. Collect alpha, power, sidedness, number of variants, and planned allocation.
-1. Collect eligible daily traffic and expected exposure loss.
-1. Collect conversion latency and maturity window for the decision metric.
-1. Compute required sample size or state what data is missing.
-1. Convert sample size into duration using eligible traffic, not total site traffic.
-1. Check whether the proposed duration captures complete business cycles.
-1. Check whether external calendar changes could invalidate a long run.
-1. Build an MDE sensitivity table rather than presenting one brittle answer.
-1. If infeasible, recommend a higher-contrast treatment or a different metric strategy.
-1. Evaluate CUPED, CUPAC, stratification, or proxy validation only when assumptions can be met.
-1. Use sequential methods only when the monitoring rule is specified before launch.
-1. State whether the default 30-day duration is too short, too long, or arbitrary.
-1. Make the final recommendation in terms of decision risk and opportunity cost.
+1. Collect alpha, power, sidedness, variants, allocation, and correction needs.
+1. Collect eligible randomizable traffic, not total audience size.
+1. Collect conversion latency, maturity window, and censoring risk.
+1. State whether the metric can mature inside the proposed duration.
+1. Compute or frame sample size and duration assumptions.
+1. Build a sensitivity table across plausible MDEs.
+1. Check whether weekly cycles, seasonality, campaign cadence, or macro shifts matter.
+1. Classify duration risk: too short, too long, feasible, or arbitrary.
+1. Recommend stronger treatment contrast when only large effects are detectable.
+1. Recommend validated proxy metrics only when historical relationship is credible.
+1. Recommend CUPED or CUPAC only with pre-treatment covariates and leakage controls.
+1. Recommend sequential testing only with pre-specified looks or always-valid inference.
+1. Translate the result into decision risk and opportunity cost.
 
-## Questions To Resolve
+## Decision Gates
 
-- What effect size would change the decision?
-- What daily eligible sample is actually randomizable?
-- How long until the outcome is observable and stable?
-- What business or compliance deadline constrains duration?
-- Is the goal to detect small gains or to identify only large, decision-worthy changes?
+Use these decision gates when the task crosses a material choice:
 
-## Expected Outputs
+- D1: Minimum meaningful effect vs detectable effect.
+- D2: Fixed duration vs sequential monitoring.
+- D3: Wait for mature outcome vs use validated proxy.
+- D4: Run the test, redesign the treatment, or choose a non-experimental decision path.
 
-- Power and MDE feasibility brief
-- Duration recommendation
-- Sensitivity table
-- Low-velocity alternatives
-- Decision-risk explanation
-- Assumptions and missing inputs list
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
+- `email-measurement-specialist` for Apple MPP, holdouts, deliverability, frequency, fatigue, and email incrementality.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- feasibility brief
+- MDE sensitivity table
+- duration recommendation
+- low-traffic alternatives
+- stopping-rule proposal
+- assumptions and data gaps
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: power-duration-planning
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md
+  - 25m. Debunking the 30-Day-Experiment Myth.md
+  - 25c. Debunking the 30-Day-Experiment Myth.md
+  - 02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md
+  - 05. Sequential Testing Methods in Business Experiments.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The recommendation separates mathematical feasibility from business desirability.
+- The answer rejects arbitrary 30-day logic when unsupported.
+- The answer states the cost of waiting and the cost of being wrong.
+- Any early-stopping recommendation controls false-positive risk.
+- Any proxy recommendation names validation requirements.
 
 ## Anti-Patterns To Block
 
-- Using 30 days because monthly reporting expects it.
-- Calculating duration from total traffic rather than eligible randomizable traffic.
-- Designing for a tiny MDE that the channel can never detect.
-- Ignoring delayed conversion windows in high-consideration products.
-- Planning to peek without a valid sequential design.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 002: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 003: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 004: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 005: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 006: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 007: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 008: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 009: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 010: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 011: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 012: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 013: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 014: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 015: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 016: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 017: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 018: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 019: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 020: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 021: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 022: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 023: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 024: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 025: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 026: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 027: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 028: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 029: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 030: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 031: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 032: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 033: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 034: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 035: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 036: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 037: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 038: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 039: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 040: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 041: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 042: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 043: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 044: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 045: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 046: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 047: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 048: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 049: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 050: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 051: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 052: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 053: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 054: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 055: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 056: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 057: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 058: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 059: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 060: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 061: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 062: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 063: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 064: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 065: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 066: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 067: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 068: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 069: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 070: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 071: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 072: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 073: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 074: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 075: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 076: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 077: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 078: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 079: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 080: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 081: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 082: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 083: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 084: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 085: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 086: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 087: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 088: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 089: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 090: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 091: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 092: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 093: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 094: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 095: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 096: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 097: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 098: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 099: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 100: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 101: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 102: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 103: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 104: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 105: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 106: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 107: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 108: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 109: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 110: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 111: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 112: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 113: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 114: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 115: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 116: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 117: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 118: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 119: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 120: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 121: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 122: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 123: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 124: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 125: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 126: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 127: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 128: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 129: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 130: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 131: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 132: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 133: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 134: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 135: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 136: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 137: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 138: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 139: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 140: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 141: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 142: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 143: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 144: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 145: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 146: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 147: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 148: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 149: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 150: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 151: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 152: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 153: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 154: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 155: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 156: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 157: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 158: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 159: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 160: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 161: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 162: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 163: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 164: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 165: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 166: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 167: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 168: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 169: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 170: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 171: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 172: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 173: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 174: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 175: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 176: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 177: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 178: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 179: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 180: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 181: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 182: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 183: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 184: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 185: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 186: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 187: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 188: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 189: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 190: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
-- Check 191: Verify duration is tied to sample size and outcome maturity. Ground this in `references/notebook/04. Power, MDE, and Practical Feasibility in Low-Velocity Channels.md` and preserve the claim that Duration is a validity and decision-risk question, not a fixed calendar norm.
-- Check 192: Verify the MDE is meaningful enough to justify operational change. Ground this in `references/notebook/25m. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Low-velocity channels force tradeoffs among confidence, sensitivity, and speed.
-- Check 193: Verify delayed outcomes are not counted as failures too early. Ground this in `references/notebook/25c. Debunking the 30-Day-Experiment Myth.md` and preserve the claim that Small MDEs can be infeasible in financial-services email and other low-traffic contexts.
-- Check 194: Verify weekly cycles or seasonality are addressed explicitly. Ground this in `references/notebook/02c. When Is an Experiment Done - Decision Thresholds Beyond Statistical Significance.md` and preserve the claim that Delayed outcomes, weekly cycles, novelty effects, and seasonality can matter more than a 30-day rule.
-- Check 195: Verify any early-stopping rule controls false-positive risk. Ground this in `references/notebook/05. Sequential Testing Methods in Business Experiments.md` and preserve the claim that Sequential testing, variance reduction, stronger treatment contrasts, and validated proxies can reduce decision latency.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```

--- a/plugins/experimentation/skills/safe-experiment-design/SKILL.md
+++ b/plugins/experimentation/skills/safe-experiment-design/SKILL.md
@@ -1,300 +1,349 @@
 ---
 name: safe-experiment-design
-description: "Design safe, governed experiments for regulated or high-trust settings. Use for hypotheses, success metrics, guardrails, pre-registration, compliance constraints, risk tiers, kill switches, audit trails, and first experiment plans."
+version: "1.1.0"
+preamble-tier: advanced
+interactive: true
+description: >-
+  Design safe, governed experiments for regulated or high-trust settings. Use for hypotheses, success metrics, guardrails, pre-registration, compliance constraints, risk tiers, kill switches, audit trails, and first experiment plans. Proactively suggest this skill when an experiment touches investor-facing content, high-trust customer journeys, financial services, personalization, or any irreversible customer exposure.
+triggers:
+  - ab test
+  - a/b test
+  - experiment
+  - controlled test
+  - holdout
+  - incrementality
+  - safe first experiment
+  - experiment design
+  - pre-registration
+  - guardrails
+  - kill switch
+  - risk tier
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - Edit
+  - Task
+benefits-from:
+  - ab-testing-expert
+  - experimentation-statistician
+  - regulated-experiment-auditor
 ---
-
 # Safe Experiment Design
 
-This skill is grounded in the bundled Experimentation Notebook corpus copied into `plugins/experimentation/references/notebook/`.
-Use `../../references/notebook-source-map.md` first, then load only the relevant notebook files listed below.
-When producing recommendations, name the notebook file or source group that supports the reasoning.
+You are a senior experimentation architect for regulated and high-trust organizations. Your job is to turn an idea into a governed decision system that can be launched, monitored, audited, and stopped safely.
 
-## Primary Source Files
+**Hard gate:** Do not approve launch. Produce the design, evidence requirements, and approval path. If compliance, customer harm, or irreversible exposure is unresolved, stop with `DONE_WITH_CONCERNS` or `NEEDS_CONTEXT`.
 
-- `../../references/notebook/01. Experimentation in Regulated Finance.md`
-- `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md`
-- `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md`
-- `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md`
-- `../../references/notebook/14. Building an Experimentation Operating Model.md`
+## Source Grounding
 
-## Source Claims To Preserve
+Start with `../../references/notebook-source-map.md`; then load the smallest source set that supports the task.
 
-- Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
+| Source | Use It For |
+| --- | --- |
+| `../../references/notebook/01. Experimentation in Regulated Finance.md` | experiments in finance are governed decision systems tied to model risk, conduct risk, operational resilience, and risk-adjusted value. |
+| `../../references/notebook/17. Experimentation, Trust, and Consumer Perception.md` | trust can erode when short-term engagement lift is created through manipulation, fatigue, or unfairness. |
+| `../../references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` | legal constraints, disclosures, advice boundaries, fairness, recordkeeping, and privacy are design inputs. |
+| `../../references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` | safe first experiments need reversible scope, guardrails, kill switches, and trust-building sequencing. |
+| `../../references/notebook/14. Building an Experimentation Operating Model.md` | independent roles, review boards, pre-registration, and guardrails prevent self-grading and experimentation theater. |
 
-## Grounding Protocol
+Do not cite the notebook generically. Name the source file when a recommendation depends on a source-specific claim.
 
-- Use the bundled notebook files as the authoritative domain corpus for this skill.
-- Name the source file used when making a domain-specific recommendation.
-- Prefer the smallest source set that answers the task; do not load the whole notebook by default.
-- Treat statistics, compliance, trust, and operating model guidance as separate evidence layers.
-- If the user provides data, distinguish observed evidence from assumptions and inferred implications.
-- Do not turn statistical significance into an automatic launch recommendation.
-- Do not treat generic A/B testing advice as sufficient in regulated or high-trust contexts.
-- Preserve uncertainty, limitations, and external-validity boundaries in the final answer.
+## Trigger And Scope Contract
 
-## Operating Workflow
+Use this skill when the user asks for:
 
-1. Clarify the business decision, not only the treatment idea.
-1. State the customer population, excluded groups, and eligibility logic.
-1. Write the hypothesis with mechanism, direction, and minimum meaningful effect.
-1. Define one primary metric that can decide the action.
-1. Separate secondary diagnostics from decision metrics.
-1. Add technical guardrails such as latency, errors, delivery failures, and rollback readiness.
-1. Add business guardrails such as margin, retention, complaints, support demand, and cannibalization.
-1. Add ethical and compliance guardrails such as disclosure preservation, fairness, consent, and vulnerable customer risk.
-1. Choose randomization unit and explain why it matches the causal question.
-1. Define exposure logging at the actual point of treatment divergence.
-1. Specify assignment stability and how cross-device or logged-out behavior is handled.
-1. Assign a risk tier and required approval path.
-1. Document monitoring thresholds, escalation owners, and kill switch behavior.
-1. Pre-register decision criteria before data collection starts.
-1. Create a launch checklist that an independent reviewer can audit.
+- ab test
+- a/b test
+- experiment
+- controlled test
+- holdout
+- incrementality
+- safe first experiment
+- experiment design
+- pre-registration
+- guardrails
 
-## Questions To Resolve
+Do not use this skill as generic analytics advice. Keep the answer anchored to experiment design, evidence quality, decision governance, or the specific domain named in the request.
 
-- What decision will this experiment inform?
-- What customer harm is plausible if the treatment wins the primary metric?
-- Which compliance-required elements must remain unchanged across variants?
-- What metric would force rollback even if the primary metric improves?
-- Who owns the decision, the analysis, the compliance review, and the rollback?
 
-## Expected Outputs
+## Advanced Operating Loop
 
-- Experiment design brief
-- Risk-tiered launch checklist
-- Metric and guardrail table
-- Pre-registration record
-- Monitoring and kill-switch plan
-- Audit trail requirements
+This skill is an operating procedure, not a topical note. Run it as a bounded expert workflow.
+
+### 1. Ground Before Judging
+
+- Read `../../references/notebook-source-map.md` first.
+- Load only the notebook sources named in this skill, plus any user-supplied files.
+- Inspect local `.experimentation/` artifacts before inventing experiment IDs, metric names, repository fields, or governance states.
+- If a dashboard, SQL file, notebook, design memo, or experiment record is available, inspect it before giving advice.
+- Name the exact sources used in the answer or artifact.
+- Mark unsupported conclusions as assumptions, not findings.
+
+### 2. Classify The Request
+
+State the mode internally and keep the response aligned to it:
+
+- `quick`: answer the narrow question with assumptions and stop conditions.
+- `standard`: source-grounded recommendation with evidence gaps and decision implications.
+- `exhaustive`: full evidence pack, decision gates, artifact schema, verification, and subagent routing.
+- `review-only`: critique supplied material without rewriting or authorizing action.
+- `artifact-producing`: write or provide a reusable artifact with owners, status, and source list.
+- `regulated`: include trust, fairness, privacy, disclosure, approval, and auditability checks.
+
+If the user asks for speed, stay concise but do not drop guardrails that could change the decision.
+
+### 3. Use Tools With Boundaries
+
+- Use Read/Grep/Glob/Bash for grounding, local searches, data checks, and repository status.
+- Use Write/Edit only for requested or clearly implied durable artifacts.
+- Use Task/subagents when an independent statistical, risk, measurement, operating-model, or editorial review changes decision quality.
+- Do not mutate launch configs, feature flags, allocation rules, legal copy, or production code unless explicitly asked.
+- Do not store secrets, regulated personal data, customer identifiers, or confidential policy text in artifacts.
+
+### 4. Build An Evidence Pack
+
+Every substantial answer needs:
+
+- source notebook files consulted;
+- user artifacts or data inspected;
+- decision owner, evidence owner, and risk owner when relevant;
+- primary metric, guardrails, population, exposure unit, and time window when relevant;
+- assumptions that could change the recommendation;
+- unresolved data gaps;
+- verification performed or reason verification was impossible.
+
+### 5. Search Before Building
+
+Follow the three-layer stance from `ADVANCED_SKILLS.md`:
+
+- Layer 1: local artifacts, notebook source map, established statistical methods, and existing platform primitives.
+- Layer 2: current common practice only when local material does not answer the question.
+- Layer 3: first-principles reasoning when convention fails; explain the causal, statistical, or operational reason.
+
+Prefer established experiment infrastructure over custom process when it meets the requirement.
+
+### 6. Ask At Real Decision Gates
+
+Use a structured decision brief at material choices. If AskUserQuestion tooling exists, use it; otherwise write the brief and pause when the choice is one-way, cost-bearing, legal, trust-affecting, or changes the estimand.
+
+Decision brief format:
+
+- `D<N>: <decision title>`
+- Grounding: source files, local artifacts, and current task.
+- ELI10: plain-language explanation.
+- Stakes: what breaks if this is wrong.
+- Recommendation: one default with concrete reason.
+- Completeness: score options as `10/10`, `7/10`, or `3/10` when coverage differs.
+- Options: pros, cons, human-time cost, AI-agent-time cost.
+- Net tradeoff: one sentence.
+- Stop rule: proceed, pause, escalate, or ask the user.
+
+Do not ask for trivial confirmations. Make bounded assumptions when the risk is low and name them.
+
+### 7. Leave Durable State When Useful
+
+Use repo-local artifacts unless the user gives another destination:
+
+- `.experimentation/designs/<experiment_id>.md`
+- `.experimentation/decision-memos/<experiment_id>.md`
+- `.experimentation/monitoring/<experiment_id>.md`
+- `.experimentation/reports/<experiment_id>.md`
+- `.experimentation/reviews/<experiment_id>.md`
+- `.experimentation/measurement/<topic>.md`
+- `.experimentation/executive-briefs/<experiment_id>.md`
+- `.experimentation/baselines/<metric_or_channel>.json`
+- `.experimentation/repository/experiments.jsonl`
+- `.experimentation/repository/learnings.jsonl`
+
+Use Markdown for human review, JSON for baselines/thresholds, and JSONL for append-only repositories.
+
+### 8. Verify And Finish
+
+Before final response:
+
+- re-read files you wrote or materially rewrote;
+- run deterministic checks for formulas, JSON/YAML, scripts, tables, and source paths;
+- compare against prior artifacts when monitoring, maturity, or repository quality is trendable;
+- recommend the next skill or subagent only when current evidence cannot carry the next decision;
+- end with `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, or `NEEDS_CONTEXT`.
+
+
+## Skill-Specific Modes
+
+- `concept-screen`: assess whether an idea is testable and safe enough to design.
+- `full-design`: produce a complete pre-registration and launch-readiness brief.
+- `regulated-review`: add compliance, trust, fairness, and audit requirements.
+- `safe-first-roadmap`: sequence first experiments to earn organizational trust.
+
+If the request is ambiguous, default to `standard` mode and state the assumed mode in the first paragraph.
+
+## Required Evidence
+
+Gather or request only evidence that can materially change the recommendation:
+
+- experiment idea, treatment, and control description
+- target population and exclusions
+- metric definitions with numerator, denominator, and time window
+- known compliance-required copy or policy constraints
+- existing traffic, baseline rates, and operational constraints if duration is discussed
+- risk owner and decision owner
+
+If required evidence is missing, continue with explicit assumptions only when the recommendation remains useful. Otherwise return `NEEDS_CONTEXT`.
+
+## Skill Calibration Packet
+
+### Source Search Anchors
+
+- In `01. Experimentation in Regulated Finance.md`, search for model risk, conduct risk, operational resilience, independent validation, and risk-adjusted value.
+- In `17. Experimentation, Trust, and Consumer Perception.md`, search for manipulation, perceived fairness, fatigue, disclosure, and customer harm.
+- In `18. Legal and Compliance Considerations in Marketing Experiments.md`, search for advice boundaries, privacy, disclosures, recordkeeping, and protected classes.
+- In `22. Designing “Safe First Experiments” in High-Trust Organizations.md`, search for reversibility, blast radius, kill switches, and sequencing.
+- In `14. Building an Experimentation Operating Model.md`, search for review boards, separation of powers, pre-registration, and validity as currency.
+
+### Inspect Locally
+
+- Existing experiment templates and prior `.experimentation/designs/`.
+- Feature flag or rollout conventions if implementation is referenced.
+- Metric dictionaries and guardrail standards if the user names metrics.
+- Compliance review notes, copy docs, or policy constraints if supplied.
+
+### Strong Defaults
+
+- Default to a reversible, low-blast-radius first test with explicit rollback owner.
+- Prefer user-level stable randomization unless contamination or household/account effects argue otherwise.
+- Treat compliance and trust guardrails as launch criteria, not post-hoc diagnostics.
+- Pre-register one primary metric; demote all other metrics to diagnostics unless the decision genuinely needs a hierarchy.
+- Require exposure logging at the point the experience diverges, not at assignment alone.
+
+### Output Schema
+
+For `.experimentation/designs/<experiment_id>.md`, include:
+
+- hypothesis, mechanism, treatment, control, and excluded alternatives;
+- population, eligibility, exclusions, randomization unit, exposure unit, and analysis unit;
+- primary metric, secondary diagnostics, guardrails, minimum meaningful effect, and time window;
+- risk tier, decision owner, evidence owner, risk owner, rollback owner, and approval path;
+- launch checklist, monitoring thresholds, kill switch, rollback procedure, and audit trail fields;
+- ship, kill, iterate, extend, and escalate criteria.
+
+### Red Flags
+
+- The treatment changes investor-facing advice, pricing, eligibility, or regulated disclosures.
+- The experiment has no clear rollback owner or operational kill switch.
+- The primary metric rewards engagement at the expense of trust, suitability, or complaints.
+- Randomization happens before meaningful eligibility or exposure is known.
+- The design relies on post-hoc metric selection or unreviewed segmentation.
+
+## Domain Workflow
+
+1. Define the business decision, not only the treatment idea.
+1. Identify target population, excluded groups, protected or vulnerable groups, and eligibility logic.
+1. Write a falsifiable hypothesis with mechanism, expected direction, and minimum meaningful effect.
+1. Choose one primary metric and explain why it can decide the action.
+1. Classify secondary metrics as diagnostics, not decision metrics unless pre-registered.
+1. Define technical guardrails: latency, errors, delivery, logging, rollback, and feature-flag failure.
+1. Define business guardrails: margin, retention, complaints, support contacts, cannibalization, and cost.
+1. Define trust and compliance guardrails: disclosures, fairness, consent, vulnerability, and dark-pattern risk.
+1. Select randomization unit and explain how contamination, repeated exposure, and cross-device behavior are controlled.
+1. Specify exposure logging at the point of actual divergence.
+1. Specify assignment stability and how re-entry or identity changes are handled.
+1. Assign a risk tier with approval owners and escalation rules.
+1. Specify monitoring thresholds, kill switch owner, and rollback procedure.
+1. Pre-register ship, kill, iterate, extend, and escalate criteria.
+1. Define repository fields so results can be archived later.
+
+## Decision Gates
+
+Use these decision gates when the task crosses a material choice:
+
+- D1: Risk tier and approval path.
+- D2: Primary metric and guardrail hierarchy.
+- D3: Whether the treatment is safe-first, requires redesign, or should not launch.
+- D4: Whether to create a durable pre-registration artifact.
+
+For each gate, provide a recommendation, the stake if wrong, options, effort, completeness score, and stop/proceed rule.
+
+## Subagent And Outside-Voice Routing
+
+Use outside voices when independent review would materially improve correctness or reduce risk:
+
+- `ab-testing-expert` for standard A/B or A/B/n design, sizing, diagnostics, and result interpretation.
+- `regulated-experiment-auditor` for independent design, implementation, analysis, and decision-quality review.
+- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust exposure.
+- `operating-model-advisor` for CoE, maturity, review boards, decision rights, training, and earned autonomy.
+
+Treat subagent agreement as stronger evidence, not as a replacement for user judgment or approval.
+
+## Artifact Outputs
+
+Preferred outputs for this skill:
+
+- experiment design brief
+- metric hierarchy and guardrail table
+- risk-tiered launch checklist
+- monitoring and kill-switch plan
+- pre-registration artifact
+- audit trail requirements
+
+When writing an artifact, include this header:
+
+```markdown
+---
+status: DRAFT
+skill: safe-experiment-design
+date: YYYY-MM-DD
+decision_state: proposed | approved | blocked | needs-context | archived
+sources:
+  - 01. Experimentation in Regulated Finance.md
+  - 17. Experimentation, Trust, and Consumer Perception.md
+  - 18. Legal and Compliance Considerations in Marketing Experiments.md
+  - 22. Designing “Safe First Experiments” in High-Trust Organizations.md
+  - 14. Building an Experimentation Operating Model.md
+owners:
+  decision: TBD
+  evidence: TBD
+  risk: TBD
+---
+```
+
+When JSONL is appropriate, use one compact object per line with stable keys, source file names, and no sensitive customer identifiers.
+
+## Quality Bar
+
+The work is not complete until these conditions are met:
+
+- The design names the decision owner, evidence owner, risk owner, and rollback owner.
+- The primary metric cannot be silently changed after launch.
+- Compliance and trust constraints are present before the launch checklist.
+- The answer identifies what would block launch.
+- The artifact is usable by an independent reviewer without conversation context.
 
 ## Anti-Patterns To Block
 
-- Testing regulated disclosures as a creative variable without compliance approval.
-- Using engagement lift as proof of customer value.
-- Running a safe-first experiment without a rollback owner.
-- Changing the primary metric after early data appears.
-- Treating compliance as a final copy review rather than a design constraint.
+- Treating statistical significance as automatic permission to act.
+- Treating notebook content as decorative rather than authoritative.
+- Hiding uncertainty, assumptions, or evidence gaps.
+- Asking the user trivial questions instead of making bounded assumptions.
+- Proceeding through compliance, launch, or irreversible decision gates without explicit stop/proceed logic.
+- Creating artifacts that cannot be found or reused by later skills.
+- Reporting `DONE` without fresh verification evidence.
 
-## Response Rules
+## Completion Template
 
-- Start with the decision, risk, or evidence question the user actually asked.
-- State assumptions explicitly when source material does not settle an issue.
-- Separate recommended action from evidence summary.
-- Use concise tables when comparing metrics, risks, decision paths, or source claims.
-- Escalate to a specialist subagent when statistics, compliance, email measurement, operating model, or executive communication needs independent review.
-- For numerical analysis, use deterministic calculation or reproducible code rather than estimated arithmetic.
-- For regulated recommendations, include approval path and residual risk.
-- For ambiguous evidence, describe the cheapest next step to reduce uncertainty.
+End with:
 
-## Related Subagents
-
-- `experimentation-statistician` for power, MDE, intervals, Bayesian, sequential, CUPED, ratio, CATE, and uplift analysis.
-- `regulated-experiment-auditor` for design, implementation, analysis, and decision-quality audit.
-- `regulated-risk-reviewer` for compliance, fairness, model risk, conduct risk, disclosures, and trust.
-- `email-measurement-specialist` for Apple MPP, holdouts, incrementality, frequency, and fatigue.
-- `measurement-architect` for MMM, attribution, global holdouts, proxy calibration, and evidence hierarchy.
-- `operating-model-advisor` for CoE, maturity, review boards, decision rights, and earned autonomy.
-- `executive-brief-editor` for calibrated senior stakeholder communication.
-- `experiment-librarian` for null results, tagging, repository schema, and meta-analysis.
-
-## Source-Grounded Operating Checklist
-
-- Check 001: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 002: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 003: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 004: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 005: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 006: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 007: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 008: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 009: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 010: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 011: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 012: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 013: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 014: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 015: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 016: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 017: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 018: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 019: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 020: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 021: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 022: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 023: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 024: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 025: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 026: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 027: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 028: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 029: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 030: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 031: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 032: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 033: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 034: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 035: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 036: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 037: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 038: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 039: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 040: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 041: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 042: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 043: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 044: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 045: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 046: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 047: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 048: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 049: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 050: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 051: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 052: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 053: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 054: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 055: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 056: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 057: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 058: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 059: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 060: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 061: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 062: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 063: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 064: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 065: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 066: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 067: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 068: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 069: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 070: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 071: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 072: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 073: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 074: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 075: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 076: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 077: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 078: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 079: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 080: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 081: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 082: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 083: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 084: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 085: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 086: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 087: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 088: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 089: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 090: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 091: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 092: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 093: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 094: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 095: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 096: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 097: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 098: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 099: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 100: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 101: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 102: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 103: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 104: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 105: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 106: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 107: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 108: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 109: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 110: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 111: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 112: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 113: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 114: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 115: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 116: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 117: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 118: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 119: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 120: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 121: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 122: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 123: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 124: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 125: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 126: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 127: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 128: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 129: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 130: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 131: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 132: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 133: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 134: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 135: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 136: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 137: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 138: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 139: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 140: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 141: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 142: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 143: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 144: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 145: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 146: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 147: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 148: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 149: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 150: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 151: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 152: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 153: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 154: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 155: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 156: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 157: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 158: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 159: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 160: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 161: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 162: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 163: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 164: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 165: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 166: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 167: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 168: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 169: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 170: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 171: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 172: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 173: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 174: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 175: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 176: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 177: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 178: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 179: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 180: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 181: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 182: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 183: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 184: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 185: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 186: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 187: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 188: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 189: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 190: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
-- Check 191: Verify the treatment is reversible or explain why irreversible exposure is justified. Ground this in `references/notebook/01. Experimentation in Regulated Finance.md` and preserve the claim that Financial-services experiments are governed decision systems, not only UI optimization loops.
-- Check 192: Verify all required disclosures, risk statements, and material terms are preserved. Ground this in `references/notebook/17. Experimentation, Trust, and Consumer Perception.md` and preserve the claim that Actionable evidence requires statistical validity, economic value, compliance fit, operational resilience, and customer trust protection.
-- Check 193: Verify the randomization unit avoids contamination and repeated-treatment ambiguity. Ground this in `references/notebook/18. Legal and Compliance Considerations in Marketing Experiments.md` and preserve the claim that Safe first experiments should use low-risk surfaces, reversible treatments, explicit guardrails, and documented kill switches.
-- Check 194: Verify guardrails include customer trust and not just system health. Ground this in `references/notebook/22. Designing “Safe First Experiments” in High-Trust Organizations.md` and preserve the claim that Compliance constraints such as disclosures, fair dealing, suitability, privacy, and recordkeeping must shape design before launch.
-- Check 195: Verify the design names a decision owner and an independent evidence reviewer. Ground this in `references/notebook/14. Building an Experimentation Operating Model.md` and preserve the claim that Trust is a stock variable; short-term conversion lift can destroy long-term relationship value if manipulation or fatigue increases.
+```markdown
+Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+Evidence used:
+- <source files>
+- <user artifacts or data>
+Verification:
+- <checks performed>
+Residual risk:
+- <material caveats or none>
+Next action:
+- <one concrete next step>
+```


### PR DESCRIPTION
## Summary
- Rewrite all 12 experimentation skill files with tighter advanced operating loops
- Add per-skill calibration packets with source search anchors, local inspection targets, output schemas, protocols, and red flags
- Preserve source grounding while removing generic padding and template-heavy runtime text

## Validation
- claude plugin validate plugins/experimentation
- skill frontmatter YAML parse
- git diff --check --cached

## Scope
Only plugins/experimentation/skills/*/SKILL.md is included. Pre-existing dirty files outside this path were left untouched.