### PR TITLE
[codex] Optimize plugin-manager skill workflows

### DIFF
--- a/plugins/plugin-manager/skills/manage-plugins/SKILL.md
+++ b/plugins/plugin-manager/skills/manage-plugins/SKILL.md
@@ -48,6 +48,9 @@ Plugin maintenance is complete only when:
   situations.
 - Cross-plugin maintenance workflows live in the `plugin-manager` plugin unless
   they are meant for end users of one specific plugin.
+- Intent is routed to the narrowest workflow that can complete it; broad
+  management does not absorb release, health, harvest, skill-improvement, or
+  full SkillOpt requests after those are identified.
 - Validation is run, or any unavailable validation command is called out.
 - Existing user edits are left untouched unless the task requires integrating
   them.
@@ -97,8 +100,13 @@ Use this skill as the first stop for plugin work, then route:
    - `plugin-update`
    - `skill-add-or-move`
    - `upstream-harvest`
+   - `skill-improve`
+   - `skillopt-training-run`
    - `marketplace-entry`
    - `validation-or-release`
+   - If the request matches a narrower workflow, route there before editing.
+     Continue only for cross-cutting coordination or when the target workflow
+     returns with an explicit handoff.
 
 3. **Apply the repo convention**
    - Distributable plugins live under `plugins/<plugin-name>/`.
@@ -120,6 +128,12 @@ Use this skill as the first stop for plugin work, then route:
    - Update `marketplace.yaml` when marketplace metadata, versions, or plugin
      entries change.
    - Run `npm run render` to refresh generated Claude Code and Codex files.
+   - Do not hand-edit `.claude-plugin/marketplace.json`,
+     `.agents/plugins/marketplace.json`, `.claude-plugin/plugin.json`, or
+     `.codex-plugin/plugin.json` to fix metadata drift; fix the source file or
+     renderer and rerun.
+   - When skill trigger text or routing intent changes, add or update
+     `routing-eval.jsonl` beside that skill.
    - Update `CLAUDE.md` or `PLUGIN_ARCHITECTURE.md` only for repo-wide
      conventions, not every small plugin change.
 
@@ -138,7 +152,7 @@ Use this skill as the first stop for plugin work, then route:
 
 ```text
 PLUGIN MANAGER RESULT
-Mode: new-plugin|plugin-update|skill-add-or-move|upstream-harvest|marketplace-entry|validation-or-release
+Mode: new-plugin|plugin-update|skill-add-or-move|upstream-harvest|skill-improve|skillopt-training-run|marketplace-entry|validation-or-release
 Plugin: <plugin-name>
 Files changed:
 - <path>
@@ -155,6 +169,8 @@ Notes:
   installable.
 - Hand-editing generated marketplace or manifest JSON instead of updating
   `marketplace.yaml` and rerendering.
+- Continuing as the router after the request clearly belongs to a narrower
+  workflow.
 - Duplicating the same maintainer workflow inside every plugin.
 - Dropping YAML frontmatter while moving skills.
 - Editing unrelated plugin files to make the diff look tidy.

--- a/plugins/plugin-manager/skills/manage-plugins/routing-eval.jsonl
+++ b/plugins/plugin-manager/skills/manage-plugins/routing-eval.jsonl
@@ -1,0 +1,4 @@
+{"intent":"create a new plugin entry and make sure the generated Claude and Codex manifests stay in sync","expected_skill":"manage-plugins"}
+{"intent":"move this maintainer workflow into plugin-manager and update the marketplace source of truth","expected_skill":"manage-plugins"}
+{"intent":"which plugin-manager workflow should handle this plugin maintenance request?","expected_skill":"manage-plugins","ambiguous_with":["plugin-health","plugin-release","skill-improve"]}
+{"intent":"add a new skill folder to an existing plugin and update the plugin docs","expected_skill":"manage-plugins","ambiguous_with":["skill-improve"]}

--- a/plugins/plugin-manager/skills/plugin-release/SKILL.md
+++ b/plugins/plugin-manager/skills/plugin-release/SKILL.md
@@ -43,6 +43,9 @@ A plugin release is ready only when:
 - README, root catalog docs, and upgrade notes reflect the shipped behavior.
 - One-way operations such as push, merge, tag, publish, and marketplace release
   happen only after explicit user approval.
+- Generated files are treated as outputs. If generated manifests or marketplace
+  files are stale, identify the source change in `marketplace.yaml` or
+  `scripts/`, rerender, and validate before release approval.
 
 ## Workflow
 
@@ -55,11 +58,17 @@ A plugin release is ready only when:
    - Inspect `git diff --stat` and relevant file diffs.
    - Classify changes: `docs-only`, `skill`, `script/tool`, `manifest`,
      `marketplace`, or `breaking`.
+   - Separate source files from generated files. Generated JSON should be
+     explainable by `marketplace.yaml` or renderer changes.
    - Flag unrelated edits; do not stage them by accident.
 
 3. **Version policy**
-   - Patch: docs, examples, small skill wording, validation fixes.
-   - Minor: new skills, new bundled tools, new workflow behavior.
+   - No bump: internal-only validation, routing fixture, or docs changes that
+     do not alter installable behavior.
+   - Patch: user-visible docs, examples, small skill wording, or validation
+     fixes.
+   - Minor: new skills, new bundled tools, new workflow behavior, or new user
+     commands.
    - Major: breaking command, path, schema, or install behavior changes.
    - Update `plugins[].version` in `marketplace.yaml`.
    - Run `npm run render` to refresh generated marketplace and manifest files.
@@ -87,6 +96,8 @@ A plugin release is ready only when:
 6. **Release gate**
    - Summarize changed files, validation evidence, version change, and upgrade
      notes.
+   - Include whether generated files are current and whether the release changes
+     Claude, Codex, or both harnesses.
    - Ask before push, PR, tag, publish, or merge.
 
 ## Output Format
@@ -102,6 +113,7 @@ Docs updated:
 - <path>
 Upgrade notes:
 - <note or none>
+Harness impact: Claude|Codex|both|none
 Release gate: ready|blocked|needs-user-approval
 ```
 
@@ -110,5 +122,7 @@ Release gate: ready|blocked|needs-user-approval
 - Bumping generated manifests by hand instead of bumping `marketplace.yaml`.
 - Publishing after tests but before docs reflect the new behavior.
 - Treating ignored/generated artifacts as source files.
+- Bumping a version for internal-only changes without saying why users need an
+  update.
 - Pushing, merging, tagging, or publishing without explicit approval.
 - Hiding upgrade impact from users with existing plugin state.

--- a/plugins/plugin-manager/skills/plugin-release/routing-eval.jsonl
+++ b/plugins/plugin-manager/skills/plugin-release/routing-eval.jsonl
@@ -1,0 +1,4 @@
+{"intent":"prepare a plugin release with version bump, render, validation, and upgrade notes","expected_skill":"plugin-release"}
+{"intent":"ship this plugin change after confirming generated manifests are current","expected_skill":"plugin-release"}
+{"intent":"bump the plugin version in marketplace.yaml and rerender both harness manifests","expected_skill":"plugin-release"}
+{"intent":"before we push and merge, verify release readiness and approval gates","expected_skill":"plugin-release","ambiguous_with":["manage-plugins"]}

--- a/plugins/plugin-manager/skills/skill-improve/SKILL.md
+++ b/plugins/plugin-manager/skills/skill-improve/SKILL.md
@@ -37,6 +37,10 @@ discipline without running SkillOpt: gather evidence, separate failures from
 working behavior, make a small bounded patch, validate it, and record what was
 changed or deliberately rejected.
 
+Use the smallest adequate validation surface. This skill should improve the
+target skill and stop; it should not become a plugin release, upstream harvest,
+or full optimization run unless evidence shows the request belongs there.
+
 Escalate to `../skillopt-training-run/SKILL.md` only when the user wants a full
 training loop, repeated rollouts, train/selection/test splits, model or harness
 comparison, slow/meta updates, or best-skill export.
@@ -56,6 +60,8 @@ comparison, slow/meta updates, or best-skill export.
      confusing trigger text, missing output contract, unsafe write scope,
      duplicated instructions, vague advice, missing anti-patterns, or examples
      of successful use worth preserving.
+   - Check whether the skill has routing fixtures. If absent or stale, treat
+     missing coverage as evidence when routing is part of the change.
    - If no concrete evidence exists, do a design review against local skill
      conventions and label the result as judgment-based.
 
@@ -70,11 +76,16 @@ comparison, slow/meta updates, or best-skill export.
    - Apply the smallest useful edit set; default to 1 to 4 focused changes.
    - Prefer localized add, replace, or delete edits over full rewrites.
    - Keep the skill concise and under the repo's existing style.
+   - Add or update `routing-eval.jsonl` only when trigger behavior or routing
+     boundaries change.
    - Do not add new scripts, references, or agents unless deterministic behavior
      or progressive disclosure clearly needs them.
 
 5. **Validation**
    - Run `python3 plugins/plugin-manager/skills/plugin-health/scripts/plugin_audit.py --plugin <plugin-name> --json`.
+   - Run `npm run render:check` and `npm run validate` when the improvement
+     changes shared plugin metadata, generated manifests, or marketplace
+     surfaces.
    - Run `claude plugin validate plugins/<plugin-name>` when available.
    - Run focused tests for any scripts or fixtures touched.
    - If validation is unavailable, state exactly what was not run.
@@ -110,4 +121,5 @@ Receipt: <path or skipped>
 - Optimizing around one anecdote without saying the evidence is thin.
 - Adding verbose background that belongs in a reference file or nowhere.
 - Removing successful behavior while fixing a failure.
+- Changing trigger/routing behavior without updating routing evidence.
 - Claiming improvement without running available validation.

--- a/plugins/plugin-manager/skills/skill-improve/routing-eval.jsonl
+++ b/plugins/plugin-manager/skills/skill-improve/routing-eval.jsonl
@@ -1,0 +1,4 @@
+{"intent":"improve this SKILL.md in one bounded pass without running a full training loop","expected_skill":"skill-improve"}
+{"intent":"tighten the trigger text and output format for this skill, then validate it","expected_skill":"skill-improve"}
+{"intent":"repair this skill after a failed plugin-health check, but keep the edit small","expected_skill":"skill-improve","ambiguous_with":["plugin-health"]}
+{"intent":"make this skill better using SkillOpt lessons but do not create train selection or test splits","expected_skill":"skill-improve","ambiguous_with":["skillopt-training-run"]}

--- a/plugins/plugin-manager/skills/upstream-skill-harvest/SKILL.md
+++ b/plugins/plugin-manager/skills/upstream-skill-harvest/SKILL.md
@@ -56,6 +56,9 @@ A harvest or sync is complete only when:
 - Privacy and fork-specific path checks run before the change is presented.
   Do not commit absolute personal paths, emails, private channels, or private
   fork names into plugin deliverables.
+- Imported skills are adapted to this repository's dual Claude Code and Codex
+  packaging model. If plugin metadata, versions, component flags, or installable
+  behavior change, update `marketplace.yaml` and rerender generated manifests.
 - A fresh upstream-diff check is captured so future maintainers can tell
   whether the plugin copy is current, intentionally forked, or stale.
 - A next-review cadence is recorded. Default to monthly for active upstream
@@ -85,8 +88,10 @@ terminology, stop and ask before changing it.
 2. Check `git status --short --branch`. Identify unrelated user edits and leave
    them alone.
 3. Confirm source roots:
-   - `GBRAIN_ROOT` points at the local GBrain checkout.
-   - `GSTACK_ROOT` points at the local GStack checkout.
+   - If using GBrain, `GBRAIN_ROOT` points at the local GBrain checkout.
+   - If using GStack, `GSTACK_ROOT` points at the local GStack checkout.
+   - If the user provided a direct source path, use it and record a stable alias
+     or sanitized repo-relative description.
    Record aliases in files, not resolved absolute paths.
 4. Resolve the source file and target path. Source may be outside this repo;
    target must be under `plugins/`.
@@ -138,8 +143,14 @@ Required adaptation checks:
 - **Sibling files:** import only files that are needed by the target skill.
   Keep `routing-eval.jsonl`, references, scripts, and assets beside the skill
   when they are part of the behavior.
+- **Routing fixtures:** if imported trigger language changes or a new skill is
+  added, add realistic `routing-eval.jsonl` examples for the intended route and
+  any common ambiguous routes.
 - **Plugin fit:** if the workflow is for maintaining plugin sources rather than
   for end users of one plugin, keep it in `plugins/plugin-manager/skills/`.
+- **Generated files:** if the harvest changes plugin metadata, versions, install
+  surfaces, or manifest fields, edit `marketplace.yaml` and run `npm run render`
+  rather than editing generated JSON directly.
 
 ## Phase 4: Record The Ledger
 
@@ -186,6 +197,8 @@ may remain when it is clearly labeled.
 Also run repo-native validation that matches the change:
 
 - Skill-only change: `python3 -m pytest tests/test_plugins/test_upstream_skill_harvest.py`
+- Routing fixture change: `python3 plugins/plugin-manager/skills/plugin-health/scripts/plugin_audit.py --plugin <plugin> --json`
+- Marketplace or manifest change: `npm run render:check` and `npm run validate`
 - Plugin package change: `claude plugin validate plugins/<plugin>` when
   available
 - KB file-vault artifact change: `vaultli --json validate --root <kb-root>`
@@ -220,6 +233,7 @@ Privacy/path check: pass|fail
 Ledger: plugins/<plugin>/references/upstream-sources.md
 Validation:
 - <command>: pass|fail
+Generated files: changed|unchanged|not-applicable
 Next review: <cadence/date>
 Files changed:
 - <path>
@@ -238,3 +252,4 @@ Files changed:
 - Importing multiple large skills at once without separate ledger entries.
 - Updating a skill without recording the upstream source SHA and adaptation
   notes.
+- Editing generated Claude or Codex manifests by hand during a harvest.

--- a/plugins/plugin-manager/skills/upstream-skill-harvest/routing-eval.jsonl
+++ b/plugins/plugin-manager/skills/upstream-skill-harvest/routing-eval.jsonl
@@ -1,0 +1,4 @@
+{"intent":"harvest this GStack skill into the knowledge-base plugin and record the upstream source","expected_skill":"upstream-skill-harvest"}
+{"intent":"refresh a plugin skill from $GBRAIN_ROOT while preserving frontmatter and ledger notes","expected_skill":"upstream-skill-harvest"}
+{"intent":"diff our plugin copy against the upstream skill and classify whether it needs refresh","expected_skill":"upstream-skill-harvest"}
+{"intent":"import this external SKILL.md but scrub private paths and add routing fixtures","expected_skill":"upstream-skill-harvest","ambiguous_with":["manage-plugins","skill-improve"]}


### PR DESCRIPTION
## Summary
- Tighten plugin-manager routing so broad management hands off to narrower release, harvest, skill-improve, and SkillOpt workflows.
- Add generated-manifest and marketplace.yaml guardrails for manage, harvest, and release workflows.
- Add routing-eval fixtures for manage-plugins, upstream-skill-harvest, skill-improve, and plugin-release.

## Validation
- `git diff --check`
- `python3 plugins/plugin-manager/skills/plugin-health/scripts/plugin_audit.py --plugin plugin-manager --strict-sections --json`
- `npm run render:check`
- `npm run validate`
- `claude plugin validate plugins/plugin-manager`
- `.venv/bin/python -m pytest tests/test_plugins/test_plugin_audit.py tests/test_plugins/test_upstream_skill_harvest.py`